### PR TITLE
Fix admin login redirect

### DIFF
--- a/inc/db.php
+++ b/inc/db.php
@@ -10,4 +10,4 @@ try {
 } catch (PDOException $e) {
     die("DB-Verbindung fehlgeschlagen: " . $e->getMessage());
 }
-?>
+


### PR DESCRIPTION
## Summary
- remove closing PHP tag from `inc/db.php`

This prevents accidental output before headers which was breaking login redirects.

## Testing
- `php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842d1d972e48321b14ae4f569d6b25d