### PR TITLE
Switch to SQLite for local testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-# website-chatgptshop
+# nezbi Shop Demo
+
+Dieses Repository enthält eine einfache PHP Shop-Demo. Für lokale Tests wird eine SQLite Datenbank verwendet.
+
+## Lokale Installation
+
+1. Abhängigkeiten installieren (PHP mit SQLite-Unterstützung):
+   ```bash
+   sudo apt-get install php-cli php-sqlite3
+   ```
+2. Datenbank erstellen:
+   ```bash
+   ./scripts/init_db.sh
+   ```
+3. Entwicklungsserver starten:
+   ```bash
+   php -S 127.0.0.1:8000
+   ```
+
+Der Shop ist anschließend unter <http://127.0.0.1:8000> erreichbar.

--- a/inc/db.php
+++ b/inc/db.php
@@ -1,13 +1,34 @@
 <?php
-$host = 'database-5017987658.webspace-host.com';
-$db   = 'dbs14303460';
-$user = 'dbu1268189';
-$pass = 'TiSch_2906_website';
-$dsn = "mysql:host=$host;port=3306;dbname=$db;charset=utf8mb4";
+// Datenbank-Verbindung
+// Standardmäßig wird eine lokale SQLite Datenbank verwendet.
+// 
+// Die Verbindung kann über Umgebungsvariablen angepasst werden:
+//   DB_TYPE  - "mysql" oder "sqlite" (Standard: sqlite)
+//   DB_HOST  - MySQL Hostname
+//   DB_NAME  - Name der MySQL Datenbank bzw. Pfad zur SQLite Datei
+//   DB_USER  - MySQL Benutzer
+//   DB_PASS  - MySQL Passwort
+
+$type = getenv('DB_TYPE') ?: 'sqlite';
+
+if ($type === 'mysql') {
+    $host = getenv('DB_HOST') ?: 'localhost';
+    $db   = getenv('DB_NAME') ?: 'nezbi';
+    $user = getenv('DB_USER') ?: 'root';
+    $pass = getenv('DB_PASS') ?: '';
+    $dsn = "mysql:host=$host;port=3306;dbname=$db;charset=utf8mb4";
+    $userpass = [$user, $pass];
+} else {
+    $db = getenv('DB_NAME') ?: __DIR__ . '/../nezbi.sqlite';
+    $dsn = "sqlite:$db";
+    $userpass = [null, null];
+}
+
 $options = [ PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION ];
+
 try {
-    $pdo = new PDO($dsn, $user, $pass, $options);
+    $pdo = new PDO($dsn, $userpass[0], $userpass[1], $options);
 } catch (PDOException $e) {
-    die("DB-Verbindung fehlgeschlagen: " . $e->getMessage());
+    die('DB-Verbindung fehlgeschlagen: ' . $e->getMessage());
 }
 

--- a/scripts/init_db.sh
+++ b/scripts/init_db.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+DB_FILE="$(dirname "$0")/../nezbi.sqlite"
+SQL_FILE="$(dirname "$0")/../sql/setup_sqlite.sql"
+if [ ! -f "$DB_FILE" ]; then
+    echo "Creating SQLite database at $DB_FILE"
+    sqlite3 "$DB_FILE" < "$SQL_FILE"
+    echo "Database created."
+else
+    echo "Database already exists at $DB_FILE"
+fi

--- a/sql/setup_sqlite.sql
+++ b/sql/setup_sqlite.sql
@@ -1,0 +1,33 @@
+CREATE TABLE produkte (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT,
+    beschreibung TEXT,
+    preis REAL,
+    bild TEXT,
+    menge INTEGER,
+    aktiv INTEGER DEFAULT 1
+);
+
+CREATE TABLE admins (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    username TEXT NOT NULL,
+    passwort TEXT NOT NULL
+);
+
+CREATE TABLE bestellungen (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    warenkorb TEXT,
+    summe REAL,
+    zeitstempel DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE rabattcodes (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    code TEXT UNIQUE,
+    typ TEXT DEFAULT 'betrag',
+    wert REAL,
+    aktiv INTEGER DEFAULT 1
+);
+
+-- Beispieladmin, Passwort ist "nezbi" (bitte nach dem Login ändern!)
+INSERT INTO admins (username, passwort) VALUES ('admin', '$2y$10$uOrlQ9bL/JzGQ/vjMVtRjeptD9kOcEvMuVgib1yJJXhwpiWY9tPja');


### PR DESCRIPTION
## Summary
- make database configurable and default to SQLite
- add setup script to create SQLite DB
- document local setup in README

## Testing
- `./scripts/init_db.sh`
- `DB_TYPE=sqlite php -S 127.0.0.1:8000`

------
https://chatgpt.com/codex/tasks/task_e_6842e254237c83218cd31165ff70ad55