### PR TITLE
Switch to MySQL only

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # nezbi Shop Demo
 
-Dieses Repository enthält eine einfache PHP Shop-Demo. Für lokale Tests wird eine SQLite Datenbank verwendet.
+Dieses Repository enthält eine einfache PHP Shop-Demo. Die Anwendung setzt ausschließlich eine MySQL-Datenbank voraus.
 
 ## Lokale Installation
 
-1. Abhängigkeiten installieren (PHP mit SQLite-Unterstützung):
+1. Abhängigkeiten installieren (PHP mit MySQL-Unterstützung):
    ```bash
-   sudo apt-get install php-cli php-sqlite3
+   sudo apt-get install php-cli php-mysql mysql-server
    ```
-2. Datenbank erstellen:
+2. Datenbank einrichten:
    ```bash
    ./scripts/init_db.sh
    ```

--- a/inc/db.php
+++ b/inc/db.php
@@ -1,34 +1,23 @@
 <?php
 // Datenbank-Verbindung
-// Standardmäßig wird eine lokale SQLite Datenbank verwendet.
-// 
-// Die Verbindung kann über Umgebungsvariablen angepasst werden:
-//   DB_TYPE  - "mysql" oder "sqlite" (Standard: sqlite)
-//   DB_HOST  - MySQL Hostname
-//   DB_NAME  - Name der MySQL Datenbank bzw. Pfad zur SQLite Datei
-//   DB_USER  - MySQL Benutzer
-//   DB_PASS  - MySQL Passwort
+// Diese Anwendung nutzt ausschließlich MySQL.
+//
+// Die Verbindung kann über folgende Umgebungsvariablen angepasst werden:
+//   DB_HOST  - MySQL Hostname (Standard: localhost)
+//   DB_NAME  - Name der MySQL Datenbank (Standard: nezbi)
+//   DB_USER  - MySQL Benutzer (Standard: root)
+//   DB_PASS  - MySQL Passwort (Standard: leer)
 
-$type = getenv('DB_TYPE') ?: 'sqlite';
-
-if ($type === 'mysql') {
-    $host = getenv('DB_HOST') ?: 'localhost';
-    $db   = getenv('DB_NAME') ?: 'nezbi';
-    $user = getenv('DB_USER') ?: 'root';
-    $pass = getenv('DB_PASS') ?: '';
-    $dsn = "mysql:host=$host;port=3306;dbname=$db;charset=utf8mb4";
-    $userpass = [$user, $pass];
-} else {
-    $db = getenv('DB_NAME') ?: __DIR__ . '/../nezbi.sqlite';
-    $dsn = "sqlite:$db";
-    $userpass = [null, null];
-}
+$host = getenv('DB_HOST') ?: 'localhost';
+$db   = getenv('DB_NAME') ?: 'nezbi';
+$user = getenv('DB_USER') ?: 'root';
+$pass = getenv('DB_PASS') ?: '';
+$dsn  = "mysql:host=$host;port=3306;dbname=$db;charset=utf8mb4";
 
 $options = [ PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION ];
 
 try {
-    $pdo = new PDO($dsn, $userpass[0], $userpass[1], $options);
+    $pdo = new PDO($dsn, $user, $pass, $options);
 } catch (PDOException $e) {
     die('DB-Verbindung fehlgeschlagen: ' . $e->getMessage());
 }
-

--- a/scripts/init_db.sh
+++ b/scripts/init_db.sh
@@ -1,11 +1,13 @@
 #!/bin/sh
 set -e
-DB_FILE="$(dirname "$0")/../nezbi.sqlite"
-SQL_FILE="$(dirname "$0")/../sql/setup_sqlite.sql"
-if [ ! -f "$DB_FILE" ]; then
-    echo "Creating SQLite database at $DB_FILE"
-    sqlite3 "$DB_FILE" < "$SQL_FILE"
-    echo "Database created."
-else
-    echo "Database already exists at $DB_FILE"
-fi
+SQL_FILE="$(dirname "$0")/../sql/setup.sql"
+DB_NAME="${DB_NAME:-nezbi}"
+DB_HOST="${DB_HOST:-localhost}"
+DB_USER="${DB_USER:-root}"
+DB_PASS="${DB_PASS:-}"
+
+echo "Creating MySQL database $DB_NAME on $DB_HOST"
+MYSQL_PWD="$DB_PASS" mysql -h "$DB_HOST" -u "$DB_USER" -e "CREATE DATABASE IF NOT EXISTS \`$DB_NAME\`;"
+MYSQL_PWD="$DB_PASS" mysql -h "$DB_HOST" -u "$DB_USER" "$DB_NAME" < "$SQL_FILE"
+
+echo "Database setup completed."


### PR DESCRIPTION
## Summary
- use MySQL as the only database backend
- update setup script to create MySQL database
- document MySQL requirements

## Testing
- `bash -n scripts/init_db.sh`
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842e60769988321bb6809d9e00ee318