### PR TITLE
Fix DB connection defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,15 @@ Dieses Repository enthält eine einfache PHP Shop-Demo. Die Anwendung setzt auss
    php -S 127.0.0.1:8000
    ```
 
+Optional können die Verbindungsdaten zur Datenbank über folgende
+Umgebungsvariablen angepasst werden:
+
+```
+DB_HOST - MySQL Hostname (Standard: 127.0.0.1)
+DB_PORT - MySQL Port (Standard: 3306)
+DB_NAME - Name der Datenbank (Standard: nezbi)
+DB_USER - MySQL Benutzer (Standard: root)
+DB_PASS - Passwort des Benutzers
+```
+
 Der Shop ist anschließend unter <http://127.0.0.1:8000> erreichbar.

--- a/inc/db.php
+++ b/inc/db.php
@@ -3,16 +3,18 @@
 // Diese Anwendung nutzt ausschließlich MySQL.
 //
 // Die Verbindung kann über folgende Umgebungsvariablen angepasst werden:
-//   DB_HOST  - MySQL Hostname (Standard: localhost)
+//   DB_HOST  - MySQL Hostname (Standard: 127.0.0.1)
+//   DB_PORT  - MySQL Port (Standard: 3306)
 //   DB_NAME  - Name der MySQL Datenbank (Standard: nezbi)
 //   DB_USER  - MySQL Benutzer (Standard: root)
 //   DB_PASS  - MySQL Passwort (Standard: leer)
 
-$host = getenv('DB_HOST') ?: 'localhost';
+$host = getenv('DB_HOST') ?: '127.0.0.1';
+$port = getenv('DB_PORT') ?: '3306';
 $db   = getenv('DB_NAME') ?: 'nezbi';
 $user = getenv('DB_USER') ?: 'root';
 $pass = getenv('DB_PASS') ?: '';
-$dsn  = "mysql:host=$host;port=3306;dbname=$db;charset=utf8mb4";
+$dsn  = "mysql:host=$host;port=$port;dbname=$db;charset=utf8mb4";
 
 $options = [ PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION ];
 


### PR DESCRIPTION
## Summary
- default to `127.0.0.1` instead of `localhost`
- allow specifying `DB_PORT`
- document environment variables used for DB connection

## Testing
- `bash scripts/init_db.sh` *(fails: `mysql` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68431d879abc8321bdf6cfb38769703a