### PR TITLE
Set default DB credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,20 @@ Optional können die Verbindungsdaten zur Datenbank über folgende
 Umgebungsvariablen angepasst werden:
 
 ```
-DB_HOST - MySQL Hostname (Standard: 127.0.0.1)
+DB_HOST - MySQL Hostname (Standard: database-5017987658.webspace-host.com)
 DB_PORT - MySQL Port (Standard: 3306)
-DB_NAME - Name der Datenbank (Standard: nezbi)
-DB_USER - MySQL Benutzer (Standard: root)
+DB_NAME - Name der Datenbank (Standard: dbs14303460)
+DB_USER - MySQL Benutzer (Standard: dbu1268189)
 DB_PASS - Passwort des Benutzers
+```
+
+Beispiel zum Setzen der Variablen in der Shell:
+
+```bash
+export DB_HOST=database-5017987658.webspace-host.com
+export DB_NAME=dbs14303460
+export DB_USER=dbu1268189
+export DB_PASS=<dein_passwort>
 ```
 
 Der Shop ist anschließend unter <http://127.0.0.1:8000> erreichbar.

--- a/inc/db.php
+++ b/inc/db.php
@@ -3,16 +3,16 @@
 // Diese Anwendung nutzt ausschließlich MySQL.
 //
 // Die Verbindung kann über folgende Umgebungsvariablen angepasst werden:
-//   DB_HOST  - MySQL Hostname (Standard: 127.0.0.1)
+//   DB_HOST  - MySQL Hostname (Standard: database-5017987658.webspace-host.com)
 //   DB_PORT  - MySQL Port (Standard: 3306)
-//   DB_NAME  - Name der MySQL Datenbank (Standard: nezbi)
-//   DB_USER  - MySQL Benutzer (Standard: root)
+//   DB_NAME  - Name der MySQL Datenbank (Standard: dbs14303460)
+//   DB_USER  - MySQL Benutzer (Standard: dbu1268189)
 //   DB_PASS  - MySQL Passwort (Standard: leer)
 
-$host = getenv('DB_HOST') ?: '127.0.0.1';
+$host = getenv('DB_HOST') ?: 'database-5017987658.webspace-host.com';
 $port = getenv('DB_PORT') ?: '3306';
-$db   = getenv('DB_NAME') ?: 'nezbi';
-$user = getenv('DB_USER') ?: 'root';
+$db   = getenv('DB_NAME') ?: 'dbs14303460';
+$user = getenv('DB_USER') ?: 'dbu1268189';
 $pass = getenv('DB_PASS') ?: '';
 $dsn  = "mysql:host=$host;port=$port;dbname=$db;charset=utf8mb4";
 

--- a/scripts/init_db.sh
+++ b/scripts/init_db.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 set -e
 SQL_FILE="$(dirname "$0")/../sql/setup.sql"
-DB_NAME="${DB_NAME:-nezbi}"
-DB_HOST="${DB_HOST:-localhost}"
-DB_USER="${DB_USER:-root}"
+DB_NAME="${DB_NAME:-dbs14303460}"
+DB_HOST="${DB_HOST:-database-5017987658.webspace-host.com}"
+DB_USER="${DB_USER:-dbu1268189}"
 DB_PASS="${DB_PASS:-}"
 
 echo "Creating MySQL database $DB_NAME on $DB_HOST"


### PR DESCRIPTION
## Summary
- apply default DB credentials from webspace hosting
- document the credentials and how to set them

## Testing
- `./scripts/init_db.sh` *(fails: mysql not found)*

------
https://chatgpt.com/codex/tasks/task_e_68431e44478083219374ff48c7fb84e7