### PR TITLE
Handle missing column when adding products

### DIFF
--- a/admin/produkte.php
+++ b/admin/produkte.php
@@ -6,6 +6,16 @@ if (!isset($_SESSION['admin'])) {
 }
 require '../inc/db.php';
 
+// Ältere Datenbanken automatisch um fehlende Spalten erweitern
+try {
+    $pdo->query("SELECT menge FROM produkte LIMIT 1");
+} catch (PDOException $e) {
+    if (strpos($e->getMessage(), 'menge') !== false) {
+        // Spalte `menge` nachrüsten, falls sie in bestehenden Installationen fehlt
+        $pdo->exec("ALTER TABLE produkte ADD COLUMN menge INT DEFAULT NULL");
+    }
+}
+
 // Aktionen für Produkte verarbeiten
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $action = $_POST['action'] ?? 'add';


### PR DESCRIPTION
## Summary
- automatically add `menge` column to outdated installations
- avoid 500 errors when creating products on old databases

## Testing
- `php -l admin/produkte.php`

------
https://chatgpt.com/codex/tasks/task_e_684327ec461c8321ab3ab01d201a42b7