### PR TITLE
Add basic customization options

### DIFF
--- a/admin/customize.php
+++ b/admin/customize.php
@@ -7,14 +7,23 @@ if (!isset($_SESSION['admin'])) {
 require '../inc/db.php';
 require '../inc/settings.php';
 $siteSettings = load_settings();
+$success = false;
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $siteSettings['primary_color'] = $_POST['primary_color'] ?? '#2563eb';
+    $siteSettings['hero_title'] = $_POST['hero_title'] ?? '';
+    $siteSettings['hero_subtitle'] = $_POST['hero_subtitle'] ?? '';
+    $siteSettings['hero_image'] = $_POST['hero_image'] ?? '';
+    $siteSettings['footer_text'] = $_POST['footer_text'] ?? '';
+    save_settings($siteSettings);
+    $success = true;
+}
 ?>
 <!DOCTYPE html>
 <html lang="de">
 <head>
     <meta charset="UTF-8">
-    <title>Dashboard – nezbi Admin</title>
+    <title>Website bearbeiten – nezbi Admin</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <!-- TailwindCSS offiziell per CDN-JS -->
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
       tailwind.config = {
@@ -26,11 +35,7 @@ $siteSettings = load_settings();
       }
     </script>
     <link href="https://fonts.googleapis.com/css?family=Inter:400,600&display=swap" rel="stylesheet">
-    <style>
-      body { font-family: 'Inter', sans-serif; }
-      :root { --accent-color: <?= htmlspecialchars($siteSettings['primary_color'] ?? '#2563eb') ?>; }
-      .accent-bg { background-color: var(--accent-color); }
-    </style>
+    <style>body { font-family: 'Inter', sans-serif; }</style>
 </head>
 <body class="bg-gray-50 text-gray-900">
     <header class="bg-white border-b shadow-sm">
@@ -46,12 +51,13 @@ $siteSettings = load_settings();
             </div>
         </div>
         <nav id="navLinks" class="hidden flex-col space-y-2 px-4 pb-4 md:flex md:flex-row md:space-y-0 md:space-x-8 md:max-w-5xl md:mx-auto">
-            <a href="dashboard.php" class="font-bold text-blue-600">Dashboard</a>
+            <a href="dashboard.php" class="hover:text-blue-600">Dashboard</a>
             <a href="produkte.php" class="hover:text-blue-600">Produkte</a>
             <a href="kategorien.php" class="hover:text-blue-600">Kategorien</a>
             <a href="rabattcodes.php" class="hover:text-blue-600">Rabatte</a>
             <a href="bestellungen.php" class="hover:text-blue-600">Bestellungen</a>
             <a href="insights.php" class="hover:text-blue-600">Insights</a>
+            <a href="customize.php" class="font-bold text-blue-600">Website bearbeiten</a>
         </nav>
     </header>
     <script>
@@ -66,29 +72,31 @@ $siteSettings = load_settings();
     });
     </script>
     <main class="max-w-5xl mx-auto px-4 py-10">
-        <h1 class="text-2xl font-bold mb-4">nezbi Admin Dashboard</h1>
-        <a href="customize.php" class="inline-block mb-8 px-4 py-2 accent-bg text-white rounded-xl">Website bearbeiten</a>
-        <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
-            <!-- Hier können Kacheln für Umsätze, Bestellungen, Produkte etc. dynamisch ergänzt werden -->
-            <div class="bg-white rounded-2xl shadow p-6">
-                <div class="text-gray-400">Produkte</div>
-                <div class="text-3xl font-bold">
-                    <?php $res = $pdo->query("SELECT COUNT(*) FROM produkte"); echo $res->fetchColumn(); ?>
-                </div>
+        <h1 class="text-2xl font-bold mb-8">Website bearbeiten</h1>
+        <?php if($success): ?><p class="mb-4 text-green-600">Einstellungen gespeichert.</p><?php endif; ?>
+        <form method="post" class="bg-white shadow rounded-xl p-6 space-y-4">
+            <div>
+                <label class="block mb-1 font-medium">Primärfarbe</label>
+                <input type="color" name="primary_color" value="<?= htmlspecialchars($siteSettings['primary_color']) ?>" class="w-24 h-10 p-0 border">
             </div>
-            <div class="bg-white rounded-2xl shadow p-6">
-                <div class="text-gray-400">Bestellungen</div>
-                <div class="text-3xl font-bold">
-                    <?php $res = $pdo->query("SELECT COUNT(*) FROM bestellungen"); echo $res->fetchColumn(); ?>
-                </div>
+            <div>
+                <label class="block mb-1 font-medium">Hero Titel</label>
+                <input type="text" name="hero_title" value="<?= htmlspecialchars($siteSettings['hero_title']) ?>" class="w-full border px-3 py-2 rounded">
             </div>
-            <div class="bg-white rounded-2xl shadow p-6">
-                <div class="text-gray-400">Gesamtumsatz</div>
-                <div class="text-3xl font-bold">
-                    <?php $res = $pdo->query("SELECT SUM(summe) FROM bestellungen"); echo number_format($res->fetchColumn(),2,',','.'); ?> €
-                </div>
+            <div>
+                <label class="block mb-1 font-medium">Hero Untertitel</label>
+                <input type="text" name="hero_subtitle" value="<?= htmlspecialchars($siteSettings['hero_subtitle']) ?>" class="w-full border px-3 py-2 rounded">
             </div>
-        </div>
+            <div>
+                <label class="block mb-1 font-medium">Hero Bild-URL</label>
+                <input type="text" name="hero_image" value="<?= htmlspecialchars($siteSettings['hero_image']) ?>" class="w-full border px-3 py-2 rounded">
+            </div>
+            <div>
+                <label class="block mb-1 font-medium">Footer Text</label>
+                <input type="text" name="footer_text" value="<?= htmlspecialchars($siteSettings['footer_text']) ?>" class="w-full border px-3 py-2 rounded">
+            </div>
+            <button class="px-5 py-2 accent-bg text-white rounded-xl">Speichern</button>
+        </form>
     </main>
 </body>
 </html>

--- a/home.php
+++ b/home.php
@@ -2,12 +2,14 @@
 $active = 'home';
 $pageTitle = 'nezbi – Elektronik Onlineshop';
 require 'inc/db.php';
+require 'inc/settings.php';
+$siteSettings = load_settings();
 include 'inc/header.php';
 ?>
-<section class="text-center py-24">
-    <h1 class="text-5xl md:text-6xl font-extrabold mb-6">Technologie neu erleben</h1>
-    <p class="text-xl md:text-2xl text-gray-600 mb-8">Premium Elektronik f&uuml;r deinen Alltag</p>
-    <a href="/index.php" class="px-8 py-3 rounded-xl bg-black text-white hover:bg-gray-800 transition">Jetzt entdecken</a>
+<section class="text-center py-24 text-white" style="background-image:url('<?= htmlspecialchars($siteSettings['hero_image']) ?>'); background-size:cover; background-position:center;">
+    <h1 class="text-5xl md:text-6xl font-extrabold mb-6"><?= htmlspecialchars($siteSettings['hero_title']) ?></h1>
+    <p class="text-xl md:text-2xl mb-8"><?= htmlspecialchars($siteSettings['hero_subtitle']) ?></p>
+    <a href="/index.php" class="px-8 py-3 rounded-xl accent-bg text-white hover:opacity-90 transition">Jetzt entdecken</a>
 </section>
 <section class="grid grid-cols-1 md:grid-cols-3 gap-8 py-16">
     <div class="text-center">

--- a/inc/footer.php
+++ b/inc/footer.php
@@ -1,4 +1,8 @@
 </main>
-<footer class="py-10 text-center text-gray-400 text-xs">© 2025 nezbi</footer>
+<?php
+require_once __DIR__.'/settings.php';
+$siteSettings = load_settings();
+?>
+<footer class="py-10 text-center text-gray-400 text-xs"><?= htmlspecialchars($siteSettings['footer_text']) ?></footer>
 </body>
 </html>

--- a/inc/header.php
+++ b/inc/header.php
@@ -1,6 +1,8 @@
 <?php
 if (!isset($pageTitle)) $pageTitle = 'nezbi – Elektronik Onlineshop';
 $active = $active ?? '';
+require_once __DIR__.'/settings.php';
+$siteSettings = load_settings();
 $kategorien = [];
 if (isset($pdo)) {
     try {
@@ -31,6 +33,9 @@ if (isset($pdo)) {
       body { font-family: 'Inter', sans-serif; }
       .fade-in { animation: fadeIn 0.6s ease-in-out; }
       @keyframes fadeIn { from { opacity:0; transform:translateY(20px);} to { opacity:1; transform:none; } }
+      :root { --accent-color: <?= htmlspecialchars($siteSettings['primary_color'] ?? '#2563eb') ?>; }
+      .accent-bg { background-color: var(--accent-color); }
+      .accent-text { color: var(--accent-color); }
     </style>
 </head>
 <body class="bg-gray-50 text-gray-900">
@@ -43,7 +48,7 @@ if (isset($pdo)) {
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
                 </svg>
             </button>
-            <a href="/warenkorb.php" class="inline-block rounded-xl px-4 py-2 bg-blue-600 text-white font-medium hover:bg-blue-700 transition">Warenkorb</a>
+            <a href="/warenkorb.php" class="inline-block rounded-xl px-4 py-2 accent-bg text-white font-medium hover:opacity-90 transition">Warenkorb</a>
         </div>
     </div>
     <nav id="navLinks" class="hidden flex-col space-y-2 px-4 pb-4 md:flex md:flex-row md:space-y-0 md:space-x-8 md:max-w-6xl md:mx-auto text-gray-700">

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -1,0 +1,24 @@
+<?php
+function load_settings(){
+    $file = __DIR__.'/../data/settings.json';
+    if (file_exists($file)) {
+        $data = json_decode(file_get_contents($file), true);
+        if (is_array($data)) return $data;
+    }
+    return [
+        'primary_color' => '#2563eb',
+        'hero_title' => 'Technologie neu erleben',
+        'hero_subtitle' => 'Premium Elektronik f\u00fcr deinen Alltag',
+        'hero_image' => 'https://images.unsplash.com/photo-1517336714731-489689fd1ca8?auto=format&fit=crop&w=1280&q=80',
+        'footer_text' => '\xc2\xa9 2025 nezbi'
+    ];
+}
+
+function save_settings($settings){
+    $file = __DIR__.'/../data/settings.json';
+    if (!is_dir(dirname($file))) {
+        mkdir(dirname($file), 0755, true);
+    }
+    file_put_contents($file, json_encode($settings, JSON_PRETTY_PRINT));
+}
+?>

--- a/index.php
+++ b/index.php
@@ -35,7 +35,7 @@ include 'inc/header.php';
             <option value="preis_asc" <?= $sort=='preis_asc'?'selected':'' ?>>Preis aufsteigend</option>
             <option value="preis_desc" <?= $sort=='preis_desc'?'selected':'' ?>>Preis absteigend</option>
         </select>
-        <button class="px-4 py-2 rounded-xl bg-blue-600 text-white">Filtern</button>
+        <button class="px-4 py-2 rounded-xl accent-bg text-white">Filtern</button>
     </form>
     <?php if (isset($filtered)): ?>
         <?php if ($filtered): ?>
@@ -58,7 +58,7 @@ include 'inc/header.php';
                             <?=number_format($prod['preis'],2,',','.')?> €
                         <?php endif; ?>
                     </div>
-                    <a href="produkt.php?id=<?=$prod['id']?>" class="mt-auto px-5 py-2 rounded-xl bg-gradient-to-r from-blue-500 to-blue-700 text-white font-semibold tracking-wide hover:shadow-lg transition">Details</a>
+                    <a href="produkt.php?id=<?=$prod['id']?>" class="mt-auto px-5 py-2 rounded-xl accent-bg text-white font-semibold tracking-wide hover:shadow-lg transition">Details</a>
                 </div>
             <?php endforeach; ?>
             </div>
@@ -91,7 +91,7 @@ include 'inc/header.php';
                         <?=number_format($prod['preis'],2,',','.')?> €
                     <?php endif; ?>
                 </div>
-                <a href="produkt.php?id=<?=$prod['id']?>" class="mt-auto px-5 py-2 rounded-xl bg-gradient-to-r from-blue-500 to-blue-700 text-white font-semibold tracking-wide hover:shadow-lg transition">Details</a>
+                <a href="produkt.php?id=<?=$prod['id']?>" class="mt-auto px-5 py-2 rounded-xl accent-bg text-white font-semibold tracking-wide hover:shadow-lg transition">Details</a>
             </div>
         <?php endforeach; ?>
         </div>
@@ -120,7 +120,7 @@ include 'inc/header.php';
                         <?=number_format($prod['preis'],2,',','.')?> €
                     <?php endif; ?>
                 </div>
-                <a href="produkt.php?id=<?=$prod['id']?>" class="mt-auto px-5 py-2 rounded-xl bg-gradient-to-r from-blue-500 to-blue-700 text-white font-semibold tracking-wide hover:shadow-lg transition">Details</a>
+                <a href="produkt.php?id=<?=$prod['id']?>" class="mt-auto px-5 py-2 rounded-xl accent-bg text-white font-semibold tracking-wide hover:shadow-lg transition">Details</a>
             </div>
         <?php endforeach; ?>
         </div>


### PR DESCRIPTION
## Summary
- load website settings from new `settings.php`
- support dynamic accent color via CSS variable
- allow customizing hero section and footer
- add `Website bearbeiten` page and link from admin dashboard

## Testing
- `sh scripts/init_db.sh` *(fails: `mysql: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684473906ba48321a5f27c064b789b7d