### PR TITLE
Add diverse templates and dark mode option

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,5 @@ Der Shop ist anschließend unter <http://127.0.0.1:8000> erreichbar.
 
 ## Website anpassen
 
-Im Adminbereich lässt sich unter "Website bearbeiten" das Aussehen anpassen. Neben Farben und Texten können fünf unterschiedliche Templates gewählt werden.
+Im Adminbereich lässt sich unter "Website bearbeiten" das Aussehen anpassen. Neben Farben und Texten stehen jetzt zehn stark unterschiedliche Templates zur Auswahl.
+Im Header der Seite befindet sich außerdem ein Button, um zwischen Light- und Darkmode zu wechseln.

--- a/admin/customize.php
+++ b/admin/customize.php
@@ -101,9 +101,22 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             <div>
                 <label class="block mb-1 font-medium">Template</label>
                 <select name="template" class="border px-3 py-2 rounded">
-                    <?php for($i=1;$i<=5;$i++): ?>
-                        <option value="<?=$i?>" <?=$siteSettings['template']==$i?'selected':''?>>Template <?=$i?></option>
-                    <?php endfor; ?>
+                    <?php
+                    $templateNames=[
+                        1=>'Klassisch',
+                        2=>'Dunkel',
+                        3=>'Pastell',
+                        4=>'Aqua',
+                        5=>'Warm',
+                        6=>'Zentrierte Navigation',
+                        7=>'Logo Mitte, Nav unten',
+                        8=>'Große Abstände',
+                        9=>'Nav linksbündig',
+                        10=>'Logo rechts, kompakt'
+                    ];
+                    foreach($templateNames as $i=>$name): ?>
+                        <option value="<?=$i?>" <?=$siteSettings['template']==$i?'selected':''?>><?=$name?></option>
+                    <?php endforeach; ?>
                 </select>
             </div>
             <div>

--- a/inc/header.php
+++ b/inc/header.php
@@ -51,6 +51,13 @@ if (isset($pdo)) {
       .accent-hover:hover { color: var(--accent-color); }
       .accent-bg-hover:hover { background-color: var(--accent-color); }
       .nav-link { color: var(--nav-link-color); }
+      /* Dark Mode */
+      body.dark{
+        --body-bg:#1f2937;
+        --header-bg:#111827;
+        --text-color:#f9fafb;
+        --nav-link-color:#d1d5db;
+      }
       /* Template Styles */
       body.template-2{
         --body-bg:#0f172a;
@@ -76,18 +83,59 @@ if (isset($pdo)) {
         --text-color:#374151;
         --nav-link-color:#78350f;
       }
+      body.template-6{
+        --body-bg:#f0f9ff;
+        --header-bg:#dbeafe;
+        --text-color:#1e3a8a;
+        --nav-link-color:#1e3a8a;
+      }
+      body.template-7{
+        --body-bg:#ffffff;
+        --header-bg:#e2e8f0;
+        --text-color:#1f2937;
+        --nav-link-color:#1f2937;
+      }
+      body.template-8{
+        --body-bg:#fef2f2;
+        --header-bg:#fee2e2;
+        --text-color:#7f1d1d;
+        --nav-link-color:#7f1d1d;
+      }
+      body.template-9{
+        --body-bg:#f0fdf4;
+        --header-bg:#dcfce7;
+        --text-color:#064e3b;
+        --nav-link-color:#064e3b;
+      }
+      body.template-10{
+        --body-bg:#faf5ff;
+        --header-bg:#ede9fe;
+        --text-color:#4c1d95;
+        --nav-link-color:#4c1d95;
+      }
+      body.template-6 nav{order:-1;margin-bottom:0.5rem;text-align:center;}
+      body.template-6 header{display:flex;flex-direction:column;align-items:center;}
+      body.template-7 header div:first-child{justify-content:center;}
+      body.template-7 nav{margin-top:1rem;text-align:center;}
+      body.template-7 .logo{margin-bottom:0.5rem;}
+      body.template-8 header div:first-child{padding-top:2rem;padding-bottom:2rem;}
+      body.template-8 nav{margin-bottom:2rem;}
+      body.template-9 nav{text-align:left;}
+      body.template-10 header div:first-child{flex-direction:row-reverse;}
+      body.template-10 nav a{margin-right:0.5rem;}
     </style>
 </head>
 <body class="template-<?= $template ?>">
 <header class="border-b shadow-sm" style="background-color: var(--header-bg);">
     <div class="max-w-6xl mx-auto flex justify-between items-center py-6 px-4">
-        <span class="text-2xl font-extrabold tracking-tight"><?= htmlspecialchars($siteSettings['logo_text'] ?? 'nezbi') ?></span>
+        <span class="logo text-2xl font-extrabold tracking-tight"><?= htmlspecialchars($siteSettings['logo_text'] ?? 'nezbi') ?></span>
         <div class="flex items-center">
             <button id="menuBtn" class="md:hidden mr-4 text-gray-600" aria-label="Menü öffnen">
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
                 </svg>
             </button>
+            <button id="themeToggle" class="mr-4 text-gray-600" aria-label="Theme wechseln">🌙</button>
             <a href="/warenkorb.php" class="inline-block rounded-xl px-4 py-2 accent-bg text-white font-medium hover:opacity-90 transition">Warenkorb</a>
         </div>
     </div>
@@ -112,6 +160,7 @@ document.addEventListener('DOMContentLoaded',function(){
   var n=document.getElementById('navLinks');
   var pBtn=document.getElementById('produkteBtn');
   var drop=document.getElementById('katDropdown');
+  var themeBtn=document.getElementById('themeToggle');
   if(b && n){
     b.addEventListener('click',function(){ n.classList.toggle('hidden'); });
   }
@@ -127,6 +176,24 @@ document.addEventListener('DOMContentLoaded',function(){
         drop.classList.add('hidden');
       }
     });
+  }
+  if(themeBtn){
+    if(localStorage.getItem('darkMode')==='1'){
+      document.body.classList.add('dark');
+    }
+    updateThemeIcon();
+    themeBtn.addEventListener('click',function(){
+      document.body.classList.toggle('dark');
+      localStorage.setItem('darkMode',document.body.classList.contains('dark')?'1':'0');
+      updateThemeIcon();
+    });
+  }
+  function updateThemeIcon(){
+    if(document.body.classList.contains('dark')){
+      themeBtn.textContent='☀️';
+    }else{
+      themeBtn.textContent='🌙';
+    }
   }
 });
 </script>


### PR DESCRIPTION
## Summary
- provide 10 unique templates in admin settings
- style differences for templates including new layouts and colors
- add dark mode toggle button in the header
- document templates and dark mode in README

## Testing
- `php -l inc/header.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68448b9f27048321bc676ee69fc49c13