### PR TITLE
Fix admin login and prevent category recreation

### DIFF
--- a/inc/db.php
+++ b/inc/db.php
@@ -31,10 +31,10 @@ try {
             $pdo->exec(file_get_contents($initFile));
         }
     } else {
+        // Ensure tables exist when using an already created SQLite database
         $pdo->exec("CREATE TABLE IF NOT EXISTS kategorien (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL)");
         $pdo->exec("CREATE TABLE IF NOT EXISTS produkte (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, beschreibung TEXT, preis REAL, rabatt REAL DEFAULT NULL, bild TEXT, menge INTEGER, aktiv INTEGER DEFAULT 1, kategorie_id INTEGER REFERENCES kategorien(id))");
-        if (!$pdo->query('SELECT COUNT(*) FROM kategorien')->fetchColumn()) {
-            $pdo->exec("INSERT INTO kategorien (name) VALUES ('Smartphones'),('Laptops'),('Audio')");
-        }
+        // Keine automatischen Standardkategorien anlegen, damit gelöschte
+        // Kategorien nicht wieder erscheinen
     }
 }

--- a/sql/setup.sql
+++ b/sql/setup.sql
@@ -44,4 +44,4 @@ CREATE TABLE rabattcodes (
 );
 
 -- Beispieladmin, Passwort ist "nezbi" (bitte nach dem Login ändern!)
-INSERT INTO admins (username, passwort) VALUES ('admin', '$2y$10$uOrlQ9bL/JzGQ/vjMVtRjeptD9kOcEvMuVgib1yJJXhwpiWY9tPja');
+INSERT INTO admins (username, passwort) VALUES ('admin', '$2y$10$2m.bMtqb4s3jLS.7BgUVleppmSDZ6Dqf1hnbdWdPNs1naaQgGo0Sy');

--- a/sql/setup_sqlite.sql
+++ b/sql/setup_sqlite.sql
@@ -42,4 +42,4 @@ CREATE TABLE rabattcodes (
 );
 
 -- Beispieladmin, Passwort ist "nezbi" (bitte nach dem Login ändern!)
-INSERT INTO admins (username, passwort) VALUES ('admin', '$2y$10$uOrlQ9bL/JzGQ/vjMVtRjeptD9kOcEvMuVgib1yJJXhwpiWY9tPja');
+INSERT INTO admins (username, passwort) VALUES ('admin', '$2y$10$2m.bMtqb4s3jLS.7BgUVleppmSDZ6Dqf1hnbdWdPNs1naaQgGo0Sy');


### PR DESCRIPTION
## Summary
- fix fallback DB not to insert default categories again
- set correct default admin password hash in both SQL setups

## Testing
- `php -l inc/db.php`
- `php -l sql/setup.sql`
- `php -l sql/setup_sqlite.sql`


------
https://chatgpt.com/codex/tasks/task_e_6844c722082483218569fd71701d5d7c