### PR TITLE
Set default DB password

### DIFF
--- a/inc/db.php
+++ b/inc/db.php
@@ -7,13 +7,13 @@
 //   DB_PORT  - MySQL Port (Standard: 3306)
 //   DB_NAME  - Name der MySQL Datenbank (Standard: dbs14303460)
 //   DB_USER  - MySQL Benutzer (Standard: dbu1268189)
-//   DB_PASS  - MySQL Passwort (Standard: leer)
+//   DB_PASS  - MySQL Passwort (Standard: TiSch_2906_website)
 
 $host = getenv('DB_HOST') ?: 'database-5017987658.webspace-host.com';
 $port = getenv('DB_PORT') ?: '3306';
 $db   = getenv('DB_NAME') ?: 'dbs14303460';
 $user = getenv('DB_USER') ?: 'dbu1268189';
-$pass = getenv('DB_PASS') ?: '';
+$pass = getenv('DB_PASS') ?: 'TiSch_2906_website';
 $dsn  = "mysql:host=$host;port=$port;dbname=$db;charset=utf8mb4";
 
 $options = [ PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION ];

--- a/scripts/init_db.sh
+++ b/scripts/init_db.sh
@@ -4,7 +4,7 @@ SQL_FILE="$(dirname "$0")/../sql/setup.sql"
 DB_NAME="${DB_NAME:-dbs14303460}"
 DB_HOST="${DB_HOST:-database-5017987658.webspace-host.com}"
 DB_USER="${DB_USER:-dbu1268189}"
-DB_PASS="${DB_PASS:-}"
+DB_PASS="${DB_PASS:-TiSch_2906_website}"
 
 echo "Creating MySQL database $DB_NAME on $DB_HOST"
 MYSQL_PWD="$DB_PASS" mysql -h "$DB_HOST" -u "$DB_USER" -e "CREATE DATABASE IF NOT EXISTS \`$DB_NAME\`;"


### PR DESCRIPTION
## Summary
- set `DB_PASS` default to `TiSch_2906_website` in MySQL connection
- apply same default in `init_db.sh`

## Testing
- `php -l inc/db.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844ccc19dcc832191854c0db041ddc7