### PR TITLE
Implement simple page builder and more customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,6 @@ Der Shop ist anschließend unter <http://127.0.0.1:8000> erreichbar.
 
 ## Website anpassen
 
-Im Adminbereich lässt sich unter "Website bearbeiten" das Aussehen anpassen. Neben Farben und Texten stehen jetzt zehn stark unterschiedliche Templates zur Auswahl.
+Im Adminbereich lässt sich unter "Website bearbeiten" das Aussehen anpassen. Neben Farben und Texten stehen jetzt zehn stark unterschiedliche Templates zur Auswahl. Zusätzlich können eine Hintergrundfarbe und eigenes CSS festgelegt werden.
 Im Header der Seite befindet sich außerdem ein Button, um zwischen Light- und Darkmode zu wechseln.
-Zusätzlich gibt es einen Bereich "Seiten", in dem sich beliebige Unterseiten erstellen und bearbeiten lassen. Die Inhalte werden mit einem einfachen Editor direkt im Browser gepflegt und erscheinen automatisch in der Navigation.
+Unter "Seiten" steht nun ein eigener Page-Builder zur Verfügung, mit dem sich Überschriften, Textabsätze, Bilder und Buttons frei zusammensetzen lassen. Die Inhalte werden lokal im Browser bearbeitet und erscheinen automatisch in der Navigation.

--- a/admin/builder.js
+++ b/admin/builder.js
@@ -1,0 +1,58 @@
+document.addEventListener('DOMContentLoaded',()=>{
+  const builder=document.getElementById('builder');
+  const addBtn=document.getElementById('addBtn');
+  const addSelect=document.getElementById('addType');
+  const form=document.getElementById('pageForm');
+  const contentInput=document.getElementById('contentInput');
+
+  if(addBtn&&addSelect&&builder){
+    addBtn.addEventListener('click',()=>{
+      const type=addSelect.value;
+      let el;
+      switch(type){
+        case 'h2':
+          el=document.createElement('h2');
+          el.textContent='Überschrift';
+          break;
+        case 'p':
+          el=document.createElement('p');
+          el.textContent='Text';
+          break;
+        case 'img':
+          el=document.createElement('img');
+          const url=prompt('Bild URL');
+          if(url) el.src=url;
+          break;
+        case 'button':
+          el=document.createElement('a');
+          el.href='#';
+          el.className='px-4 py-2 rounded bg-blue-600 text-white inline-block';
+          el.textContent='Button';
+          break;
+        default:
+          el=document.createElement('p');
+          el.textContent='Text';
+      }
+      el.contentEditable=type!=='img';
+      el.classList.add('editable');
+      const wrapper=document.createElement('div');
+      wrapper.className='block relative group mb-2';
+      const del=document.createElement('button');
+      del.type='button';
+      del.textContent='✖';
+      del.className='absolute -right-2 -top-2 hidden group-hover:block bg-red-600 text-white rounded-full w-5 h-5 text-xs';
+      del.addEventListener('click',()=>wrapper.remove());
+      wrapper.appendChild(el);
+      wrapper.appendChild(del);
+      builder.appendChild(wrapper);
+    });
+  }
+
+  if(form&&contentInput&&builder){
+    form.addEventListener('submit',()=>{
+      const clones=builder.cloneNode(true);
+      clones.querySelectorAll('button').forEach(b=>b.remove());
+      contentInput.value=clones.innerHTML;
+    });
+  }
+});

--- a/admin/customize.php
+++ b/admin/customize.php
@@ -18,6 +18,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $siteSettings['hero_subtitle'] = $_POST['hero_subtitle'] ?? '';
     $siteSettings['hero_image'] = $_POST['hero_image'] ?? '';
     $siteSettings['footer_text'] = $_POST['footer_text'] ?? '';
+    $siteSettings['background_color'] = $_POST['background_color'] ?? '#f9fafb';
+    $siteSettings['custom_css'] = $_POST['custom_css'] ?? '';
     save_settings($siteSettings);
     $success = true;
 }
@@ -41,11 +43,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <?php $ff = $siteSettings['font_family'] ?? 'Inter'; $ff_link = str_replace(' ', '+', $ff); ?>
     <link href="https://fonts.googleapis.com/css?family=<?= $ff_link ?>:400,600&display=swap" rel="stylesheet">
     <style>
-      body { font-family: '<?= htmlspecialchars($ff) ?>', sans-serif; }
+      body { font-family: '<?= htmlspecialchars($ff) ?>', sans-serif; background-color: <?= htmlspecialchars($siteSettings['background_color']) ?>; }
       :root { --accent-color: <?= htmlspecialchars($siteSettings['primary_color']) ?>; }
       .accent-bg { background-color: var(--accent-color); }
       .accent-hover:hover { color: var(--accent-color); }
       .accent-bg-hover:hover { background-color: var(--accent-color); }
+      <?= $siteSettings['custom_css'] ?>
     </style>
 </head>
 <body class="bg-gray-50 text-gray-900">
@@ -144,6 +147,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             <div>
                 <label class="block mb-1 font-medium">Footer Text</label>
                 <input type="text" name="footer_text" value="<?= htmlspecialchars($siteSettings['footer_text']) ?>" class="w-full border px-3 py-2 rounded">
+            </div>
+            <div>
+                <label class="block mb-1 font-medium">Hintergrundfarbe</label>
+                <input type="color" name="background_color" value="<?= htmlspecialchars($siteSettings['background_color']) ?>" class="w-24 h-10 p-0 border">
+            </div>
+            <div>
+                <label class="block mb-1 font-medium">Eigenes CSS</label>
+                <textarea name="custom_css" rows="4" class="w-full border px-3 py-2 rounded"><?= htmlspecialchars($siteSettings['custom_css']) ?></textarea>
             </div>
             <button class="px-5 py-2 accent-bg text-white rounded-xl">Speichern</button>
         </form>

--- a/admin/edit_page.php
+++ b/admin/edit_page.php
@@ -40,8 +40,7 @@ if($_SERVER['REQUEST_METHOD']==='POST' && !$action){
 <title>Seite bearbeiten – nezbi Admin</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <script src="https://cdn.tailwindcss.com"></script>
-<script src="https://cdn.tiny.cloud/1/no-api-key/tinymce/6/tinymce.min.js" referrerpolicy="origin"></script>
-<script>document.addEventListener('DOMContentLoaded',function(){tinymce.init({selector:'#content',height:400});});</script>
+<script src="builder.js"></script>
 <link href="https://fonts.googleapis.com/css?family=Inter:400,600&display=swap" rel="stylesheet">
 <style>body{font-family:'Inter',sans-serif;}</style>
 </head>
@@ -86,8 +85,23 @@ document.addEventListener('DOMContentLoaded',function(){var b=document.getElemen
     </div>
     <div>
         <label class="block mb-1 font-medium">Inhalt</label>
-        <textarea id="content" name="content" class="w-full border px-3 py-2 rounded" rows="10"><?= htmlspecialchars($page['content']) ?></textarea>
+        <div id="builder" class="w-full border px-3 py-2 rounded min-h-[200px]"></div>
+        <input type="hidden" id="contentInput" name="content">
+        <div class="flex items-center mt-2 space-x-2">
+            <select id="addType" class="border px-2 py-1 rounded">
+                <option value="p">Text</option>
+                <option value="h2">Überschrift</option>
+                <option value="img">Bild</option>
+                <option value="button">Button</option>
+            </select>
+            <button type="button" id="addBtn" class="px-3 py-1 bg-gray-200 rounded">Hinzufügen</button>
+        </div>
     </div>
+    <script>
+    document.addEventListener('DOMContentLoaded',function(){
+        document.getElementById('builder').innerHTML = <?= json_encode($page['content']) ?>;
+    });
+    </script>
     <button class="px-5 py-2 bg-blue-600 text-white rounded-xl">Speichern</button>
 </form>
 </main>

--- a/inc/header.php
+++ b/inc/header.php
@@ -47,7 +47,7 @@ if (isset($pdo)) {
       :root {
         --accent-color: <?= htmlspecialchars($siteSettings['primary_color'] ?? '#2563eb') ?>;
         --secondary-color: <?= htmlspecialchars($siteSettings['secondary_color'] ?? '#1e40af') ?>;
-        --body-bg: #f9fafb;
+        --body-bg: <?= htmlspecialchars($siteSettings['background_color'] ?? '#f9fafb') ?>;
         --header-bg: #ffffff;
         --text-color: #111827;
         --nav-link-color: #374151;
@@ -129,6 +129,7 @@ if (isset($pdo)) {
       body.template-9 nav{text-align:left;}
       body.template-10 header div:first-child{flex-direction:row-reverse;}
       body.template-10 nav a{margin-right:0.5rem;}
+      <?= $siteSettings['custom_css'] ?? '' ?>
     </style>
 </head>
 <body class="template-<?= $template ?>">

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -10,7 +10,9 @@ function load_settings(){
         'hero_title' => 'Technologie neu erleben',
         'hero_subtitle' => 'Premium Elektronik f\u00fcr deinen Alltag',
         'hero_image' => 'https://images.unsplash.com/photo-1517336714731-489689fd1ca8?auto=format&fit=crop&w=1280&q=80',
-        'footer_text' => '\xc2\xa9 2025 nezbi'
+        'footer_text' => '\xc2\xa9 2025 nezbi',
+        'background_color' => '#f9fafb',
+        'custom_css' => ''
     ];
     if (file_exists($file)) {
         $data = json_decode(file_get_contents($file), true);


### PR DESCRIPTION
## Summary
- build a minimal page editor without TinyMCE
- add background color and custom CSS options
- support new settings in site header and admin customize page
- document the new features in README

## Testing
- `php -l` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68460460ac0c83218ec45014a1067f4f