### PR TITLE
Enhance page builder buttons and slug hint

### DIFF
--- a/admin/builder.js
+++ b/admin/builder.js
@@ -25,9 +25,11 @@ document.addEventListener('DOMContentLoaded',()=>{
           break;
         case 'button':
           el=document.createElement('a');
-          el.href='#';
+          const btnText=prompt('Button Text','Button');
+          const link=prompt('Link URL (z.B. https://example.com oder /seite)','');
+          if(link) el.href=link; else el.href='#';
           el.className='px-4 py-2 rounded bg-blue-600 text-white inline-block';
-          el.textContent='Button';
+          el.textContent=btnText||'Button';
           break;
         default:
           el=document.createElement('p');
@@ -45,6 +47,16 @@ document.addEventListener('DOMContentLoaded',()=>{
       wrapper.appendChild(el);
       wrapper.appendChild(del);
       builder.appendChild(wrapper);
+    });
+  }
+
+  if(builder){
+    builder.addEventListener('dblclick',e=>{
+      if(e.target.tagName==='A' && e.target.classList.contains('editable')){
+        const current=e.target.getAttribute('href')||'';
+        const newUrl=prompt('Link URL (z.B. https://example.com oder /seite)',current);
+        if(newUrl!==null) e.target.setAttribute('href',newUrl);
+      }
     });
   }
 

--- a/admin/edit_page.php
+++ b/admin/edit_page.php
@@ -73,7 +73,7 @@ document.addEventListener('DOMContentLoaded',function(){var b=document.getElemen
 </script>
 <main class="max-w-5xl mx-auto px-4 py-10">
 <h1 class="text-2xl font-bold mb-8">Seite bearbeiten</h1>
-<form method="post" class="bg-white shadow rounded-xl p-6 space-y-4">
+<form method="post" id="pageForm" class="bg-white shadow rounded-xl p-6 space-y-4">
     <input type="hidden" name="id" value="<?= htmlspecialchars($id) ?>">
     <div>
         <label class="block mb-1 font-medium">Titel</label>
@@ -81,7 +81,8 @@ document.addEventListener('DOMContentLoaded',function(){var b=document.getElemen
     </div>
     <div>
         <label class="block mb-1 font-medium">Slug (URL)</label>
-        <input type="text" name="slug" value="<?= htmlspecialchars($page['slug']) ?>" class="w-full border px-3 py-2 rounded" required>
+        <input type="text" name="slug" value="<?= htmlspecialchars($page['slug']) ?>" class="w-full border px-3 py-2 rounded" placeholder="z.B. testseite" required>
+        <p class="text-sm text-gray-500 mt-1">Beispiel: <code>testseite</code> ergibt die URL <code>nezbi.de/testseite</code></p>
     </div>
     <div>
         <label class="block mb-1 font-medium">Inhalt</label>


### PR DESCRIPTION
## Summary
- allow button elements in the page builder to define text and link
- enable editing the link by double clicking on a button
- add an id to the form so builder.js saves content
- show an URL example hint when editing page slug

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68460698ea008321b6a45392274c8a7e