### PR TITLE
Add website editor link to admin navbar

### DIFF
--- a/admin/dashboard.php
+++ b/admin/dashboard.php
@@ -53,6 +53,7 @@ $siteSettings = load_settings();
             <a href="bestellungen.php" class="hover:text-blue-600">Bestellungen</a>
             <a href="insights.php" class="hover:text-blue-600">Insights</a>
             <a href="pages.php" class="hover:text-blue-600">Seiten</a>
+            <a href="customize.php" class="hover:text-blue-600">Website bearbeiten</a>
             <a href="templates.php" class="hover:text-blue-600">Templates</a>
         </nav>
     </header>


### PR DESCRIPTION
## Summary
- show Website bearbeiten link in admin dashboard navbar

## Testing
- `php -l admin/dashboard.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68485a95b4bc8321aad98e3b731d38d1