### PR TITLE
Add basic page builder

### DIFF
--- a/admin/builder.js
+++ b/admin/builder.js
@@ -1,0 +1,81 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const editor=document.getElementById('editor');
+  const addText=document.getElementById('addText');
+  const addImage=document.getElementById('addImage');
+  const addSection=document.getElementById('addSection');
+  const contentInput=document.getElementById('contentInput');
+  const previewFrame=document.getElementById('previewFrame');
+  const stylePanel=document.getElementById('stylePanel');
+  const bgInput=document.getElementById('bgInput');
+  const padInput=document.getElementById('padInput');
+  let selected=null;
+
+  function updatePreview(){
+    previewFrame.srcdoc=editor.innerHTML;
+  }
+
+  function select(el){
+    if(selected) selected.classList.remove('selected');
+    selected=el; if(el){el.classList.add('selected');
+      bgInput.value=rgbToHex(window.getComputedStyle(el).backgroundColor);
+      padInput.value=parseInt(window.getComputedStyle(el).padding)||0;
+      stylePanel.hidden=false;
+    } else {
+      stylePanel.hidden=true;
+    }
+  }
+
+  function rgbToHex(rgb){
+    const res=/rgba?\((\d+),(\d+),(\d+)/.exec(rgb);
+    if(!res) return '#ffffff';
+    return '#'+res.slice(1,4).map(x=>('0'+parseInt(x).toString(16)).slice(-2)).join('');
+  }
+
+  function makeEditable(el){
+    el.addEventListener('click',e=>{e.stopPropagation(); select(el);});
+  }
+
+  function addWidget(type){
+    let el;
+    if(type==='text'){
+      el=document.createElement('div');
+      el.contentEditable=true;
+      el.textContent='Text';
+      el.className='p-2';
+    }else if(type==='image'){
+      const url=prompt('Bild URL:'); if(!url) return;
+      el=document.createElement('img');
+      el.src=url;
+      el.className='';
+    }else if(type==='section'){
+      el=document.createElement('div');
+      el.className='p-4 border';
+      el.textContent='Bereich';
+    }
+    el.classList.add('block');
+    makeEditable(el);
+    editor.appendChild(el);
+    updatePreview();
+  }
+
+  addText.onclick=()=>addWidget('text');
+  addImage.onclick=()=>addWidget('image');
+  addSection.onclick=()=>addWidget('section');
+
+  editor.addEventListener('input',updatePreview);
+  document.addEventListener('click',()=>select(null));
+  bgInput.oninput=()=>{if(selected){selected.style.backgroundColor=bgInput.value; updatePreview();}}
+  padInput.oninput=()=>{if(selected){selected.style.padding=padInput.value+'px'; updatePreview();}}
+
+  new Sortable(editor,{animation:150});
+
+  if(contentInput.value.trim()){
+    editor.innerHTML=contentInput.value;
+    editor.querySelectorAll('*').forEach(makeEditable);
+  }
+  updatePreview();
+
+  document.getElementById('pageForm').addEventListener('submit',()=>{
+    contentInput.value=editor.innerHTML;
+  });
+});

--- a/admin/page_builder.php
+++ b/admin/page_builder.php
@@ -1,0 +1,90 @@
+<?php
+session_start();
+if(!isset($_SESSION['admin'])){header('Location: ../login.php');exit;}
+require '../inc/db.php';
+$action = $_POST['action'] ?? null;
+$id = isset($_GET['id']) ? intval($_GET['id']) : 0;
+$page = ['title'=>'','slug'=>'','content'=>''];
+if($id){
+    $stmt=$pdo->prepare('SELECT * FROM pages WHERE id=?');
+    $stmt->execute([$id]);
+    $row=$stmt->fetch(PDO::FETCH_ASSOC);
+    if($row) $page=$row;
+}
+if($_SERVER['REQUEST_METHOD']==='POST' && !$action){
+    $title=$_POST['title']??'';
+    $slug=preg_replace('/[^a-z0-9-]/','-', strtolower(trim($_POST['slug']??'')));
+    $content=$_POST['content']??'';
+    if($id){
+        $stmt=$pdo->prepare('UPDATE pages SET title=?, slug=?, content=? WHERE id=?');
+        $stmt->execute([$title,$slug,$content,$id]);
+    }else{
+        $stmt=$pdo->prepare('INSERT INTO pages (title,slug,content) VALUES (?,?,?)');
+        $stmt->execute([$title,$slug,$content]);
+        $id=$pdo->lastInsertId();
+    }
+    header('Location: pages.php');
+    exit;
+}
+?>
+<!DOCTYPE html>
+<html lang="de">
+<head>
+<meta charset="UTF-8">
+<title>Page Builder – nezbi Admin</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="https://cdn.tailwindcss.com"></script>
+<script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
+<link href="https://fonts.googleapis.com/css?family=Inter:400,600&display=swap" rel="stylesheet">
+<style>body{font-family:'Inter',sans-serif;}#editor .selected{outline:2px dashed #3b82f6;}</style>
+</head>
+<body class="bg-gray-50 text-gray-900">
+<header class="bg-white border-b shadow-sm">
+    <div class="max-w-5xl mx-auto flex justify-between items-center py-6 px-4">
+        <span class="text-2xl font-extrabold tracking-tight">nezbi Admin</span>
+        <div class="flex items-center">
+            <a href="logout.php" class="inline-block rounded-xl px-4 py-2 bg-blue-600 text-white font-medium hover:bg-blue-700 transition">Logout</a>
+        </div>
+    </div>
+    <nav class="flex space-x-8 max-w-5xl mx-auto px-4 pb-4">
+        <a href="dashboard.php" class="hover:text-blue-600">Dashboard</a>
+        <a href="pages.php" class="font-bold text-blue-600">Seiten</a>
+    </nav>
+</header>
+<main class="max-w-5xl mx-auto px-4 py-10">
+<h1 class="text-2xl font-bold mb-8">Page Builder</h1>
+<form method="post" id="pageForm" class="bg-white shadow rounded-xl p-6 space-y-4">
+    <input type="hidden" name="id" value="<?= htmlspecialchars($id) ?>">
+    <div>
+        <label class="block mb-1 font-medium">Titel</label>
+        <input type="text" name="title" value="<?= htmlspecialchars($page['title']) ?>" class="w-full border px-3 py-2 rounded" required>
+    </div>
+    <div>
+        <label class="block mb-1 font-medium">Slug (URL)</label>
+        <input type="text" name="slug" value="<?= htmlspecialchars($page['slug']) ?>" class="w-full border px-3 py-2 rounded" required>
+    </div>
+    <div class="flex">
+        <div id="editor" class="border rounded min-h-[400px] flex-1 p-2 space-y-2"></div>
+        <div class="ml-4 space-y-2 w-40 text-sm">
+            <button type="button" id="addText" class="w-full px-2 py-1 bg-gray-200 rounded">Text</button>
+            <button type="button" id="addImage" class="w-full px-2 py-1 bg-gray-200 rounded">Bild</button>
+            <button type="button" id="addSection" class="w-full px-2 py-1 bg-gray-200 rounded">Section</button>
+            <div class="border rounded p-2" id="stylePanel" hidden>
+                <label class="block text-xs">Hintergrund</label>
+                <input type="color" id="bgInput" class="w-full h-6 mb-2">
+                <label class="block text-xs">Padding</label>
+                <input type="number" id="padInput" class="w-full border mb-2" min="0" step="1">
+            </div>
+        </div>
+    </div>
+    <input type="hidden" id="contentInput" name="content" value="<?= htmlspecialchars($page['content']) ?>">
+    <div class="mt-6">
+        <label class="block mb-1 font-medium">Vorschau</label>
+        <iframe id="previewFrame" class="w-full h-96 border rounded"></iframe>
+    </div>
+    <button class="px-5 py-2 bg-blue-600 text-white rounded-xl">Speichern</button>
+</form>
+</main>
+<script src="builder.js"></script>
+</body>
+</html>

--- a/admin/pages.php
+++ b/admin/pages.php
@@ -48,7 +48,7 @@ document.addEventListener('DOMContentLoaded',function(){
 </script>
 <main class="max-w-5xl mx-auto px-4 py-10">
     <h1 class="text-2xl font-bold mb-8">Seiten</h1>
-    <a href="edit_page.php" class="mb-4 inline-block px-4 py-2 bg-blue-600 text-white rounded">Neue Seite</a>
+    <a href="page_builder.php" class="mb-4 inline-block px-4 py-2 bg-blue-600 text-white rounded">Neue Seite</a>
     <div class="overflow-x-auto">
     <table class="w-full bg-white shadow rounded-xl">
         <thead class="bg-gray-100"><tr><th class="p-2 text-left">ID</th><th class="p-2 text-left">Titel</th><th class="p-2 text-left">Slug</th><th class="p-2">Aktionen</th></tr></thead>
@@ -59,7 +59,7 @@ document.addEventListener('DOMContentLoaded',function(){
                 <td class="p-2"><?= htmlspecialchars($p['title']) ?></td>
                 <td class="p-2"><?= htmlspecialchars($p['slug']) ?></td>
                 <td class="p-2">
-                    <a href="edit_page.php?id=<?= $p['id'] ?>" class="px-3 py-1 bg-blue-600 text-white rounded mr-2">Bearbeiten</a>
+                    <a href="page_builder.php?id=<?= $p['id'] ?>" class="px-3 py-1 bg-blue-600 text-white rounded mr-2">Bearbeiten</a>
                     <form method="post" action="edit_page.php" onsubmit="return confirm('Seite wirklich löschen?')" class="inline">
                         <input type="hidden" name="id" value="<?= $p['id'] ?>">
                         <input type="hidden" name="action" value="delete">


### PR DESCRIPTION
## Summary
- create a new `page_builder.php` for admin pages
- add accompanying `builder.js` with drag/drop editing and basic styling
- update admin page list to use the new builder

## Testing
- `node --check admin/builder.js`
- `php` was unavailable so no further syntax checks could be run

------
https://chatgpt.com/codex/tasks/task_e_68487ff0452c8321aa9ee049ac3f8a35