### PR TITLE
Add widget config panel

### DIFF
--- a/pagebuilder/assets/builder.css
+++ b/pagebuilder/assets/builder.css
@@ -9,4 +9,74 @@
   padding: 0.5rem;
   margin-bottom: 0.5rem;
   cursor: move;
+  position: relative;
+}
+
+/* Overlay controls */
+.pb-controls {
+  position: absolute;
+  top: 0.25rem;
+  right: 0.25rem;
+  z-index: 10;
+}
+
+.pb-controls button {
+  background: #fff;
+  border: 1px solid #cbd5e1;
+  padding: 0.125rem 0.25rem;
+  font-size: 0.75rem;
+  border-radius: 0.25rem;
+}
+
+/* Konfigurationspanel */
+.pb-config-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 50;
+}
+
+.pb-config {
+  background: #fff;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  width: 280px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
+  font-size: 0.875rem;
+}
+
+.pb-config label {
+  display: block;
+  margin-bottom: 0.5rem;
+}
+
+.pb-config input[type="text"],
+.pb-config input[type="color"] {
+  width: 100%;
+  border: 1px solid #cbd5e1;
+  padding: 0.25rem;
+  border-radius: 0.25rem;
+}
+
+.pb-config-actions {
+  text-align: right;
+  margin-top: 0.5rem;
+}
+
+.pb-config-actions button {
+  margin-left: 0.25rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
+}
+
+/* Sichtbarkeitsklassen */
+@media (max-width: 768px) {
+  .pb-hide-mobile { display: none !important; }
+}
+
+@media (min-width: 769px) {
+  .pb-hide-desktop { display: none !important; }
 }

--- a/pagebuilder/assets/builder.js
+++ b/pagebuilder/assets/builder.js
@@ -24,6 +24,77 @@ function initBuilder() {
       }
     });
     el.addEventListener('input', save);
+
+    // Einstellungs-Button hinzufügen
+    if (!el.querySelector('.pb-controls')) {
+      const controls = document.createElement('div');
+      controls.className = 'pb-controls';
+      controls.innerHTML = '<button type="button">Einstellungen</button>';
+      controls.querySelector('button').addEventListener('click', (e) => {
+        e.stopPropagation();
+        openConfigPanel(el);
+      });
+      el.appendChild(controls);
+    }
+
+    // vorhandene Konfiguration anwenden
+    if (el.dataset.config) {
+      try {
+        const cfg = JSON.parse(el.dataset.config);
+        applyConfig(el, cfg);
+      } catch (e) {
+        console.error('Config Fehler', e);
+      }
+    }
+  }
+
+  function applyConfig(el, cfg) {
+    if (!cfg) return;
+    el.style.fontSize = cfg.fontSize || '';
+    el.style.color = cfg.color || '';
+    el.style.background = cfg.background || '';
+    el.style.padding = cfg.padding || '';
+    el.style.margin = cfg.margin || '';
+    if (cfg.hideMobile) el.classList.add('pb-hide-mobile');
+    else el.classList.remove('pb-hide-mobile');
+    if (cfg.hideDesktop) el.classList.add('pb-hide-desktop');
+    else el.classList.remove('pb-hide-desktop');
+  }
+
+  function openConfigPanel(el) {
+    const cfg = el.dataset.config ? JSON.parse(el.dataset.config) : {};
+    const overlay = document.createElement('div');
+    overlay.className = 'pb-config-overlay';
+    overlay.innerHTML = `<div class="pb-config">
+      <label>Schriftgr\u00f6\u00dfe <input type="text" name="fontSize" value="${cfg.fontSize || ''}"></label>
+      <label>Textfarbe <input type="color" name="color" value="${cfg.color || '#000000'}"></label>
+      <label>Hintergrund <input type="color" name="background" value="${cfg.background || '#ffffff'}"></label>
+      <label>Padding <input type="text" name="padding" value="${cfg.padding || ''}"></label>
+      <label>Margin <input type="text" name="margin" value="${cfg.margin || ''}"></label>
+      <label><input type="checkbox" name="hideMobile" ${cfg.hideMobile ? 'checked' : ''}> Auf mobilen Ger\u00e4ten ausblenden</label>
+      <label><input type="checkbox" name="hideDesktop" ${cfg.hideDesktop ? 'checked' : ''}> Auf Desktops ausblenden</label>
+      <div class="pb-config-actions">
+        <button type="button" class="pb-cancel">Abbrechen</button>
+        <button type="button" class="pb-save">Speichern</button>
+      </div>
+    </div>`;
+    document.body.appendChild(overlay);
+    overlay.querySelector('.pb-cancel').addEventListener('click', () => overlay.remove());
+    overlay.querySelector('.pb-save').addEventListener('click', () => {
+      const data = {
+        fontSize: overlay.querySelector('input[name="fontSize"]').value.trim(),
+        color: overlay.querySelector('input[name="color"]').value,
+        background: overlay.querySelector('input[name="background"]').value,
+        padding: overlay.querySelector('input[name="padding"]').value.trim(),
+        margin: overlay.querySelector('input[name="margin"]').value.trim(),
+        hideMobile: overlay.querySelector('input[name="hideMobile"]').checked,
+        hideDesktop: overlay.querySelector('input[name="hideDesktop"]').checked
+      };
+      el.dataset.config = JSON.stringify(data);
+      applyConfig(el, data);
+      save();
+      overlay.remove();
+    });
   }
 
   async function fetchWidget(name) {


### PR DESCRIPTION
## Summary
- add config UI for widgets in the admin page builder
- style new panel and control elements
- store widget config JSON on the element

## Testing
- `node --check pagebuilder/assets/builder.js`
- ❌ `php -l admin/modular_builder.php` (failed: `php: command not found`)


------
https://chatgpt.com/codex/tasks/task_e_684990b007108321b70e6d4143a2603b