### PR TITLE
Add server side persistence for modular builder

### DIFF
--- a/admin/modular_builder.php
+++ b/admin/modular_builder.php
@@ -4,6 +4,19 @@ if(!isset($_SESSION['admin'])){header('Location: ../login.php');exit;}
 require '../inc/db.php';
 require '../pagebuilder/builder.php';
 
+$id = isset($_GET['id']) ? intval($_GET['id']) : 0;
+$page = ['title' => '', 'slug' => '', 'layout' => ''];
+if ($id) {
+    $stmt = $pdo->prepare('SELECT * FROM builder_pages WHERE id=?');
+    $stmt->execute([$id]);
+    if ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+        $page['title'] = $row['title'];
+        $page['slug'] = $row['slug'];
+        $d = json_decode($row['layout'], true);
+        $page['layout'] = $d['html'] ?? '';
+    }
+}
+
 $builder = new ModularPageBuilder();
 $widgets = $builder->loadWidgets(__DIR__ . '/../pagebuilder/widgets');
 ?>
@@ -35,8 +48,15 @@ $widgets = $builder->loadWidgets(__DIR__ . '/../pagebuilder/widgets');
 </header>
 <main class="max-w-5xl mx-auto px-4 py-10">
 <h1 class="text-2xl font-bold mb-8">Modularer Page Builder</h1>
+<div class="mb-4 space-y-2">
+    <input type="text" id="pbTitle" value="<?= htmlspecialchars($page['title']) ?>" placeholder="Titel" class="w-full border px-2 py-1 rounded">
+    <input type="text" id="pbSlug" value="<?= htmlspecialchars($page['slug']) ?>" placeholder="Slug" class="w-full border px-2 py-1 rounded">
+    <button type="button" id="pbSave" class="px-4 py-2 bg-blue-600 text-white rounded">Speichern</button>
+</div>
 <div class="flex">
-    <div class="pb-canvas flex-1" id="builderCanvas"></div>
+    <div class="pb-canvas flex-1" id="builderCanvas" data-save-url="../pagebuilder/save_page.php" data-load-url="<?= $id ? '../pagebuilder/load_page.php?id='.$id : '' ?>" data-page-id="<?= $id ?>">
+        <?= $id ? '' : $page['layout']; ?>
+    </div>
     <div class="ml-4 w-40 text-sm space-y-2" id="widgetBar">
         <?php foreach($widgets as $name => $file): ?>
             <button type="button" class="w-full px-2 py-1 bg-gray-200 rounded" data-widget="<?= htmlspecialchars($name) ?>"><?= htmlspecialchars($name) ?></button>

--- a/inc/db.php
+++ b/inc/db.php
@@ -35,6 +35,7 @@ try {
         $pdo->exec("CREATE TABLE IF NOT EXISTS kategorien (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL)");
         $pdo->exec("CREATE TABLE IF NOT EXISTS produkte (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, beschreibung TEXT, preis REAL, rabatt REAL DEFAULT NULL, bild TEXT, menge INTEGER, aktiv INTEGER DEFAULT 1, kategorie_id INTEGER REFERENCES kategorien(id))");
         $pdo->exec("CREATE TABLE IF NOT EXISTS pages (id INTEGER PRIMARY KEY AUTOINCREMENT, slug TEXT UNIQUE, title TEXT, content TEXT)");
+        $pdo->exec("CREATE TABLE IF NOT EXISTS builder_pages (id INTEGER PRIMARY KEY AUTOINCREMENT, slug TEXT UNIQUE, title TEXT, layout TEXT)");
         // Keine automatischen Standardkategorien anlegen, damit gelöschte
         // Kategorien nicht wieder erscheinen
     }
@@ -47,7 +48,9 @@ try {
     $driver = $pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
     if ($driver === 'sqlite') {
         $pdo->exec("CREATE TABLE IF NOT EXISTS pages (id INTEGER PRIMARY KEY AUTOINCREMENT, slug TEXT UNIQUE, title TEXT, content TEXT)");
+        $pdo->exec("CREATE TABLE IF NOT EXISTS builder_pages (id INTEGER PRIMARY KEY AUTOINCREMENT, slug TEXT UNIQUE, title TEXT, layout TEXT)");
     } else {
         $pdo->exec("CREATE TABLE IF NOT EXISTS pages (id INT AUTO_INCREMENT PRIMARY KEY, slug VARCHAR(200) UNIQUE, title VARCHAR(200), content TEXT)");
+        $pdo->exec("CREATE TABLE IF NOT EXISTS builder_pages (id INT AUTO_INCREMENT PRIMARY KEY, slug VARCHAR(200) UNIQUE, title VARCHAR(200), layout TEXT)");
     }
 }

--- a/pagebuilder/load_page.php
+++ b/pagebuilder/load_page.php
@@ -1,0 +1,29 @@
+<?php
+session_start();
+if (!isset($_SESSION['admin'])) { http_response_code(403); exit('Forbidden'); }
+require __DIR__ . '/../inc/db.php';
+
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$slug = $_GET['slug'] ?? '';
+if ($id) {
+    $stmt = $pdo->prepare('SELECT * FROM builder_pages WHERE id=?');
+    $stmt->execute([$id]);
+} elseif ($slug !== '') {
+    $stmt = $pdo->prepare('SELECT * FROM builder_pages WHERE slug=?');
+    $stmt->execute([$slug]);
+} else {
+    http_response_code(400);
+    echo json_encode(['error' => 'missing']);
+    exit;
+}
+$page = $stmt->fetch(PDO::FETCH_ASSOC);
+if (!$page) { http_response_code(404); echo json_encode(['error'=>'not found']); exit; }
+$data = json_decode($page['layout'], true);
+$layout = $data['html'] ?? '';
+
+echo json_encode([
+    'id' => $page['id'],
+    'title' => $page['title'],
+    'slug' => $page['slug'],
+    'layout' => $layout
+]);

--- a/pagebuilder/save_page.php
+++ b/pagebuilder/save_page.php
@@ -1,0 +1,27 @@
+<?php
+session_start();
+if (!isset($_SESSION['admin'])) { http_response_code(403); exit('Forbidden'); }
+require __DIR__ . '/../inc/db.php';
+
+$input = json_decode(file_get_contents('php://input'), true);
+if (!$input) {
+    http_response_code(400);
+    echo json_encode(['error' => 'invalid']);
+    exit;
+}
+
+$title = $input['title'] ?? '';
+$slug  = isset($input['slug']) ? preg_replace('/[^a-z0-9-]/', '-', strtolower(trim($input['slug']))) : '';
+$layout = json_encode(['html' => $input['layout'] ?? ''], JSON_UNESCAPED_UNICODE);
+$id = isset($input['id']) ? (int)$input['id'] : 0;
+
+if ($id > 0) {
+    $stmt = $pdo->prepare('UPDATE builder_pages SET title=?, slug=?, layout=? WHERE id=?');
+    $stmt->execute([$title, $slug, $layout, $id]);
+} else {
+    $stmt = $pdo->prepare('INSERT INTO builder_pages (title, slug, layout) VALUES (?,?,?)');
+    $stmt->execute([$title, $slug, $layout]);
+    $id = $pdo->lastInsertId();
+}
+
+echo json_encode(['id' => $id]);

--- a/sql/setup.sql
+++ b/sql/setup.sql
@@ -52,3 +52,10 @@ CREATE TABLE pages (
     title VARCHAR(200),
     content TEXT
 );
+
+CREATE TABLE builder_pages (
+    id INT PRIMARY KEY AUTO_INCREMENT,
+    slug VARCHAR(200) UNIQUE,
+    title VARCHAR(200),
+    layout TEXT
+);

--- a/sql/setup_sqlite.sql
+++ b/sql/setup_sqlite.sql
@@ -50,3 +50,10 @@ CREATE TABLE pages (
     title TEXT,
     content TEXT
 );
+
+CREATE TABLE builder_pages (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    slug TEXT UNIQUE,
+    title TEXT,
+    layout TEXT
+);


### PR DESCRIPTION
## Summary
- store page builder layouts as JSON in new `builder_pages` table
- provide `save_page.php` and `load_page.php` APIs
- load/save pages in the modular builder UI
- ensure tables exist for MySQL/SQLite

## Testing
- `php -l pagebuilder/save_page.php`
- `php -l pagebuilder/load_page.php`
- `php -l admin/modular_builder.php`
- `php -l inc/db.php`
- `php -l pagebuilder/assets/builder.js`

------
https://chatgpt.com/codex/tasks/task_e_6849919eef9c8321b9fbc68bf8c09873