### PR TITLE
Add dynamic product & category widgets

### DIFF
--- a/admin/modular_builder.php
+++ b/admin/modular_builder.php
@@ -70,5 +70,6 @@ $widgets = $builder->loadWidgets(__DIR__ . '/../pagebuilder/widgets');
 </div>
 </main>
 <script src="../pagebuilder/assets/builder.js"></script>
+<script src="../assets/dynamic-widgets.js"></script>
 </body>
 </html>

--- a/assets/dynamic-widgets.js
+++ b/assets/dynamic-widgets.js
@@ -1,0 +1,27 @@
+(function(){
+  async function loadProductGrid(el){
+    const params=new URLSearchParams();
+    if(el.dataset.category) params.append('category', el.dataset.category);
+    if(el.dataset.limit) params.append('limit', el.dataset.limit);
+    const res=await fetch('/pagebuilder/api/product_grid.php?'+params.toString());
+    if(res.ok){
+      el.innerHTML=await res.text();
+    }else{
+      el.textContent='Fehler beim Laden';
+    }
+  }
+  async function loadCategoryList(el){
+    const params=new URLSearchParams();
+    if(el.dataset.limit) params.append('limit', el.dataset.limit);
+    const res=await fetch('/pagebuilder/api/category_list.php?'+params.toString());
+    if(res.ok){
+      el.innerHTML=await res.text();
+    }else{
+      el.textContent='Fehler beim Laden';
+    }
+  }
+  document.addEventListener('DOMContentLoaded',function(){
+    document.querySelectorAll('.pb-product-grid').forEach(loadProductGrid);
+    document.querySelectorAll('.pb-category-list').forEach(loadCategoryList);
+  });
+})();

--- a/inc/footer.php
+++ b/inc/footer.php
@@ -4,5 +4,6 @@ require_once __DIR__.'/settings.php';
 $siteSettings = load_settings();
 ?>
 <footer class="py-10 text-center text-gray-400 text-xs"><?= htmlspecialchars($siteSettings['footer_text']) ?></footer>
+<script src="/assets/dynamic-widgets.js"></script>
 </body>
 </html>

--- a/pagebuilder/api/category_list.php
+++ b/pagebuilder/api/category_list.php
@@ -1,0 +1,12 @@
+<?php
+require __DIR__ . '/../../inc/db.php';
+$limit = isset($_GET['limit']) ? intval($_GET['limit']) : 10;
+$stmt = $pdo->prepare('SELECT id, name FROM kategorien ORDER BY name LIMIT ?');
+$stmt->execute([$limit]);
+$cats = $stmt->fetchAll(PDO::FETCH_ASSOC);
+?>
+<ul class="space-y-2">
+<?php foreach ($cats as $cat): ?>
+    <li><a href="/kategorie.php?id=<?=$cat['id']?>" class="text-blue-600 hover:underline"><?=htmlspecialchars($cat['name'])?></a></li>
+<?php endforeach; ?>
+</ul>

--- a/pagebuilder/api/product_grid.php
+++ b/pagebuilder/api/product_grid.php
@@ -1,0 +1,35 @@
+<?php
+require __DIR__ . '/../../inc/db.php';
+$category = isset($_GET['category']) ? intval($_GET['category']) : 0;
+$limit = isset($_GET['limit']) ? intval($_GET['limit']) : 6;
+$sql = "SELECT * FROM produkte WHERE aktiv=1";
+$params = [];
+if ($category > 0) { $sql .= " AND kategorie_id=?"; $params[] = $category; }
+$sql .= " ORDER BY id DESC LIMIT ?";
+$params[] = $limit;
+$stmt = $pdo->prepare($sql);
+$stmt->execute($params);
+$produkte = $stmt->fetchAll(PDO::FETCH_ASSOC);
+?>
+<div class="grid gap-8 grid-cols-1 md:grid-cols-3">
+<?php foreach ($produkte as $prod): ?>
+    <div class="bg-white rounded-2xl shadow-lg p-6 flex flex-col items-center hover:scale-105 transition">
+        <div class="relative w-40 h-40 mb-4">
+            <?php if ($prod['rabatt'] && $prod['rabatt'] < $prod['preis']): ?>
+                <span class="absolute top-1 left-1 z-10 bg-red-600 text-white text-xs px-2 py-1 rounded-br">Angebot</span>
+            <?php endif; ?>
+            <img src="<?=htmlspecialchars($prod['bild'])?>" alt="<?=htmlspecialchars($prod['name'])?>" class="w-full h-full object-contain" />
+        </div>
+        <div class="font-bold text-lg mb-1 text-center break-words"><?=htmlspecialchars($prod['name'])?></div>
+        <div class="font-mono text-lg mb-4">
+            <?php if ($prod['rabatt'] && $prod['rabatt'] < $prod['preis']): ?>
+                <span class="line-through mr-2 text-gray-500"><?=number_format($prod['preis'],2,',','.')?> €</span>
+                <span class="text-red-600 font-bold"><?=number_format($prod['rabatt'],2,',','.')?> €</span>
+            <?php else: ?>
+                <?=number_format($prod['preis'],2,',','.')?> €
+            <?php endif; ?>
+        </div>
+        <a href="/produkt.php?id=<?=$prod['id']?>" class="mt-auto px-5 py-2 rounded-xl accent-bg text-white font-semibold tracking-wide accent-bg-hover transition">Details</a>
+    </div>
+<?php endforeach; ?>
+</div>

--- a/pagebuilder/assets/builder.js
+++ b/pagebuilder/assets/builder.js
@@ -134,6 +134,14 @@ function initBuilder() {
     else el.classList.remove('pb-hide-mobile');
     if (cfg.hideDesktop) el.classList.add('pb-hide-desktop');
     else el.classList.remove('pb-hide-desktop');
+
+    if (el.dataset.widget === 'product_grid') {
+      if (cfg.category !== undefined) el.dataset.category = cfg.category;
+      if (cfg.limit !== undefined) el.dataset.limit = cfg.limit;
+    }
+    if (el.dataset.widget === 'category_list') {
+      if (cfg.limit !== undefined) el.dataset.limit = cfg.limit;
+    }
   }
 
   function openConfigPanel(el) {
@@ -141,6 +149,14 @@ function initBuilder() {
     const bpCfg = cfg.breakpoints ? cfg.breakpoints[currentBreakpoint] || {} : cfg;
     const overlay = document.createElement('div');
     overlay.className = 'pb-config-overlay';
+    let widgetFields = '';
+    if (el.dataset.widget === 'product_grid') {
+      widgetFields += `<label>Kategorie-ID <input type="number" name="category" value="${cfg.category || ''}"></label>`;
+      widgetFields += `<label>Anzahl <input type="number" name="limit" value="${cfg.limit || 6}"></label>`;
+    } else if (el.dataset.widget === 'category_list') {
+      widgetFields += `<label>Anzahl <input type="number" name="limit" value="${cfg.limit || 10}"></label>`;
+    }
+
     overlay.innerHTML = `<div class="pb-config">
       <div class="pb-config-bp">${currentBreakpoint.toUpperCase()}</div>
       <label>Schriftgr\u00f6\u00dfe <input type="text" name="fontSize" value="${bpCfg.fontSize || ''}"></label>
@@ -148,6 +164,7 @@ function initBuilder() {
       <label>Hintergrund <input type="color" name="background" value="${bpCfg.background || '#ffffff'}"></label>
       <label>Padding <input type="text" name="padding" value="${bpCfg.padding || ''}"></label>
       <label>Margin <input type="text" name="margin" value="${bpCfg.margin || ''}"></label>
+      ${widgetFields}
       <label><input type="checkbox" name="hideMobile" ${cfg.hideMobile ? 'checked' : ''}> Auf mobilen Ger\u00e4ten ausblenden</label>
       <label><input type="checkbox" name="hideDesktop" ${cfg.hideDesktop ? 'checked' : ''}> Auf Desktops ausblenden</label>
       <div class="pb-config-actions">
@@ -169,6 +186,12 @@ function initBuilder() {
       };
       data.hideMobile = overlay.querySelector('input[name="hideMobile"]').checked;
       data.hideDesktop = overlay.querySelector('input[name="hideDesktop"]').checked;
+      if (el.dataset.widget === 'product_grid') {
+        data.category = overlay.querySelector('input[name="category"]').value.trim();
+        data.limit = overlay.querySelector('input[name="limit"]').value.trim();
+      } else if (el.dataset.widget === 'category_list') {
+        data.limit = overlay.querySelector('input[name="limit"]').value.trim();
+      }
       el.dataset.config = JSON.stringify(data);
       applyConfig(el, data);
       save();
@@ -186,6 +209,7 @@ function initBuilder() {
     if (!html) return;
     const wrapper = document.createElement('div');
     wrapper.className = 'pb-item';
+    wrapper.dataset.widget = name;
     wrapper.innerHTML = html;
     canvas.appendChild(wrapper);
     makeEditable(wrapper);

--- a/pagebuilder/widgets/category_list.php
+++ b/pagebuilder/widgets/category_list.php
@@ -1,0 +1,1 @@
+<div class="pb-category-list" data-limit="10">Kategorien werden geladen...</div>

--- a/pagebuilder/widgets/product_grid.php
+++ b/pagebuilder/widgets/product_grid.php
@@ -1,0 +1,1 @@
+<div class="pb-product-grid" data-category="" data-limit="6">Produkt-Grid wird geladen...</div>


### PR DESCRIPTION
## Summary
- add dynamic widgets JS
- implement server-side endpoints for product grids and category lists
- add placeholder widgets for page builder
- extend builder to configure widget parameters
- load dynamic widgets on frontend

## Testing
- `php -l pagebuilder/api/product_grid.php`
- `php -l pagebuilder/api/category_list.php`
- `php -l admin/modular_builder.php`


------
https://chatgpt.com/codex/tasks/task_e_684996616a188321b32bbaf3cfc6ff60