### PR TITLE
Allow page builder layouts for existing pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Neu ist außerdem eine Seite "Templates" im Adminbereich. Dort finden sich CSS�
 
 Ebenfalls neu ist ein modularer visueller Page Builder. Die zugehörigen Dateien befinden sich im Verzeichnis `pagebuilder` und können im Adminbereich über den Menüpunkt "Builder" aufgerufen werden. Jedes Widget besteht aus einer PHP-Datei sowie einem HTML-Template. Per Drag & Drop können aktuell zehn Beispiel-Widgets wie Text, Bild oder Video auf die Seite gezogen werden. Neu ist außerdem ein Breakpoint-System für Desktop, Tablet und Mobile. Für jeden Viewport lassen sich individuelle Einstellungen speichern und die Vorschau im Editor umschalten.
 
+Der Builder kann nun auch für bestehende Shop-Seiten wie die Startseite, Kategorien oder CMS-Seiten verwendet werden. Liegt für eine Seite ein Eintrag in `builder_pages` vor, ersetzt das dort gespeicherte Layout den regulären Inhalt. Über den Parameter `?classic=1` lässt sich jederzeit zum Standardlayout zurückkehren.
+
 ## Globale Templates
 
 Im Verzeichnis `templates` liegen wiederverwendbare Abschnitte wie `header.php`, `footer.php` oder `cta.php`. Mit der Funktion `render_template()` aus `inc/template.php` lassen sich diese Bereiche auf beliebigen Seiten einbinden:

--- a/about.php
+++ b/about.php
@@ -1,6 +1,7 @@
 <?php
 $active = 'about';
 require 'inc/db.php';
+require_once 'inc/pagebuilder.php';
 $stmt = $pdo->prepare('SELECT title, content, meta_title, meta_description, canonical_url, jsonld FROM pages WHERE slug = ?');
 $stmt->execute(['about']);
 $page = $stmt->fetch(PDO::FETCH_ASSOC);
@@ -9,7 +10,16 @@ $metaDescription = $page['meta_description'] ?? '';
 $canonicalUrl = $page['canonical_url'] ?? '';
 $jsonLd = $page['jsonld'] ?? '';
 require_once "inc/template.php";
+$builderLayout = null;
+if (!isset($_GET['classic'])) {
+    $builderLayout = get_builder_layout($pdo, 'about');
+}
 include 'inc/header.php';
+if ($builderLayout) {
+    echo $builderLayout;
+    include 'inc/footer.php';
+    return;
+}
 if ($page) {
     echo $page['content'];
 } else {

--- a/inc/pagebuilder.php
+++ b/inc/pagebuilder.php
@@ -1,0 +1,16 @@
+<?php
+function get_builder_layout(PDO $pdo, string $slug): ?string {
+    try {
+        $stmt = $pdo->prepare('SELECT layout FROM builder_pages WHERE slug=?');
+        $stmt->execute([$slug]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        if ($row) {
+            $data = json_decode($row['layout'], true);
+            return $data['html'] ?? '';
+        }
+    } catch (Exception $e) {
+        // ignore errors and fall back to default
+    }
+    return null;
+}
+?>

--- a/index.php
+++ b/index.php
@@ -2,10 +2,21 @@
 $active = 'home';
 $pageTitle = 'nezbi – Elektronik Onlineshop';
 require 'inc/db.php';
+require_once 'inc/pagebuilder.php';
 require 'inc/settings.php';
 $siteSettings = load_settings();
 require_once "inc/template.php";
+
+$builderLayout = null;
+if (!isset($_GET['classic'])) {
+    $builderLayout = get_builder_layout($pdo, 'home');
+}
 include 'inc/header.php';
+if ($builderLayout) {
+    echo $builderLayout;
+    include 'inc/footer.php';
+    return;
+}
 ?>
 <section class="relative text-center py-24 text-white" style="background-image:url('<?= htmlspecialchars($siteSettings['hero_image']) ?>'); background-size:cover; background-position:center;">
     <div class="absolute inset-0 bg-black/40"></div>

--- a/kategorie.php
+++ b/kategorie.php
@@ -1,5 +1,6 @@
 <?php
 require 'inc/db.php';
+require_once 'inc/pagebuilder.php';
 $id = intval($_GET['id'] ?? 0);
 $stmt = $pdo->prepare("SELECT * FROM kategorien WHERE id=?");
 $stmt->execute([$id]);
@@ -7,7 +8,16 @@ $kategorie = $stmt->fetch();
 if (!$kategorie) { http_response_code(404); exit('Kategorie nicht gefunden.'); }
 $active = 'produkte';
 $pageTitle = htmlspecialchars($kategorie['name']) . ' – nezbi';
+$builderLayout = null;
+if (!isset($_GET['classic'])) {
+    $builderLayout = get_builder_layout($pdo, 'category-' . $id);
+}
 include 'inc/header.php';
+if ($builderLayout) {
+    echo $builderLayout;
+    include 'inc/footer.php';
+    return;
+}
 ?>
 <section class="py-16">
     <h2 class="text-3xl font-bold mb-8 text-center"><?= htmlspecialchars($kategorie['name']) ?></h2>

--- a/page.php
+++ b/page.php
@@ -1,5 +1,6 @@
 <?php
 require 'inc/db.php';
+require_once 'inc/pagebuilder.php';
 $slug = $_GET['slug'] ?? '';
 $stmt = $pdo->prepare('SELECT * FROM pages WHERE slug = ?');
 $stmt->execute([$slug]);
@@ -18,7 +19,16 @@ $metaDescription = $page['meta_description'] ?? '';
 $canonicalUrl = $page['canonical_url'] ?? '';
 $jsonLd = $page['jsonld'] ?? '';
 $active = $slug;
+$builderLayout = null;
+if (!isset($_GET['classic'])) {
+    $builderLayout = get_builder_layout($pdo, $slug);
+}
 include 'inc/header.php';
+if ($builderLayout) {
+    echo $builderLayout;
+    include 'inc/footer.php';
+    return;
+}
 echo '<section class="py-24 max-w-3xl mx-auto">'.$page['content'].'</section>';
 include 'inc/footer.php';
 ?>


### PR DESCRIPTION
## Summary
- add `inc/pagebuilder.php` to load stored builder layouts
- show builder layout for home, category and CMS pages if available
- allow fallback via `?classic=1` parameter
- document the new behaviour in README

## Testing
- `php -l inc/pagebuilder.php`
- `php -l index.php`
- `php -l about.php`
- `php -l page.php`
- `php -l kategorie.php`


------
https://chatgpt.com/codex/tasks/task_e_6849a0c96e5c8321b449c9f1f7674d4f