### PR TITLE
Implement live preview panel

### DIFF
--- a/admin/modular_builder.php
+++ b/admin/modular_builder.php
@@ -60,13 +60,16 @@ $widgets = $builder->loadWidgets(__DIR__ . '/../pagebuilder/widgets');
     </div>
 </div>
 <div class="flex">
-    <div class="pb-canvas flex-1" id="builderCanvas" data-save-url="../pagebuilder/save_page.php" data-load-url="<?= $id ? '../pagebuilder/load_page.php?id='.$id : '' ?>" data-page-id="<?= $id ?>">
-        <?= $id ? '' : $page['layout']; ?>
+    <div class="w-60 mr-4 space-y-4" id="leftPanel">
+        <div id="pbConfigPanel" class="pb-config"></div>
+        <div class="text-sm space-y-2" id="widgetBar">
+            <?php foreach($widgets as $name => $file): ?>
+                <button type="button" class="w-full px-2 py-1 bg-gray-200 rounded" data-widget="<?= htmlspecialchars($name) ?>"><?= htmlspecialchars($name) ?></button>
+            <?php endforeach; ?>
+        </div>
     </div>
-    <div class="ml-4 w-40 text-sm space-y-2" id="widgetBar">
-        <?php foreach($widgets as $name => $file): ?>
-            <button type="button" class="w-full px-2 py-1 bg-gray-200 rounded" data-widget="<?= htmlspecialchars($name) ?>"><?= htmlspecialchars($name) ?></button>
-        <?php endforeach; ?>
+    <div class="pb-canvas flex-1 border" id="builderCanvas" data-save-url="../pagebuilder/save_page.php" data-load-url="<?= $id ? '../pagebuilder/load_page.php?id='.$id : '' ?>" data-page-id="<?= $id ?>">
+        <?= $id ? '' : $page['layout']; ?>
     </div>
 </div>
 </main>

--- a/pagebuilder/assets/builder.css
+++ b/pagebuilder/assets/builder.css
@@ -72,6 +72,14 @@
   border-radius: 0.25rem;
 }
 
+#pbConfigPanel.pb-config {
+  width: 100%;
+  box-shadow: none;
+  border: 1px solid #cbd5e1;
+}
+#pbConfigPanel { display: none; }
+#pbConfigPanel.active { display: block; }
+
 /* Breakpoint Preview */
 .pb-preview-desktop { width: 100%; }
 .pb-preview-tablet { width: 768px; margin: 0 auto; }


### PR DESCRIPTION
## Summary
- update page builder layout to include a persistent configuration panel
- add live updates for style changes while editing widgets
- open the panel when clicking a widget for immediate preview
- adjust builder styles for the side panel

## Testing
- `node --check pagebuilder/assets/builder.js`
- `php -l admin/modular_builder.php` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849a26929288321857ddc71762b1f64