### PR TITLE
Implement popup builder

### DIFF
--- a/about.php
+++ b/about.php
@@ -9,6 +9,7 @@ $pageTitle = $page['meta_title'] ?: ($page['title'] ?? 'Über nezbi');
 $metaDescription = $page['meta_description'] ?? '';
 $canonicalUrl = $page['canonical_url'] ?? '';
 $jsonLd = $page['jsonld'] ?? '';
+$currentSlug = 'about';
 require_once "inc/template.php";
 $builderLayout = null;
 if (!isset($_GET['classic'])) {

--- a/admin/bestellungen.php
+++ b/admin/bestellungen.php
@@ -49,6 +49,7 @@ $bestellungen = $pdo->query("SELECT * FROM bestellungen ORDER BY zeitstempel DES
             <a href="insights.php" class="hover:text-blue-600">Insights</a>
             <a href="pages.php" class="hover:text-blue-600">Seiten</a>
         <a href="modular_builder.php" class="hover:text-blue-600">Builder</a>
+        <a href="popup_builder.php" class="hover:text-blue-600">Popups</a>
             <a href="templates.php" class="hover:text-blue-600">Templates</a>
         </nav>
     </header>

--- a/admin/customize.php
+++ b/admin/customize.php
@@ -64,6 +64,7 @@ if($_SERVER['REQUEST_METHOD']==='POST'){
         <a href="insights.php" class="hover:text-blue-600">Insights</a>
         <a href="pages.php" class="hover:text-blue-600">Seiten</a>
         <a href="modular_builder.php" class="hover:text-blue-600">Builder</a>
+        <a href="popup_builder.php" class="hover:text-blue-600">Popups</a>
         <a href="customize.php" class="font-bold text-blue-600">Website bearbeiten</a>
         <a href="templates.php" class="hover:text-blue-600">Templates</a>
     </nav>

--- a/admin/dashboard.php
+++ b/admin/dashboard.php
@@ -54,6 +54,7 @@ $siteSettings = load_settings();
             <a href="insights.php" class="hover:text-blue-600">Insights</a>
             <a href="pages.php" class="hover:text-blue-600">Seiten</a>
         <a href="modular_builder.php" class="hover:text-blue-600">Builder</a>
+        <a href="popup_builder.php" class="hover:text-blue-600">Popups</a>
             <a href="customize.php" class="hover:text-blue-600">Website bearbeiten</a>
             <a href="templates.php" class="hover:text-blue-600">Templates</a>
         </nav>

--- a/admin/edit_page.php
+++ b/admin/edit_page.php
@@ -70,6 +70,7 @@ if($_SERVER['REQUEST_METHOD']==='POST' && !$action){
         <a href="insights.php" class="hover:text-blue-600">Insights</a>
         <a href="pages.php" class="text-blue-600 font-bold">Seiten</a>
         <a href="modular_builder.php" class="hover:text-blue-600">Builder</a>
+        <a href="popup_builder.php" class="hover:text-blue-600">Popups</a>
         <a href="customize.php" class="hover:text-blue-600">Website bearbeiten</a>
         <a href="templates.php" class="hover:text-blue-600">Templates</a>
     </nav>

--- a/admin/insights.php
+++ b/admin/insights.php
@@ -50,6 +50,7 @@ $tage = $pdo->query("SELECT DATE(zeitstempel) AS tag, COUNT(*) AS anzahl, SUM(su
             <a href="insights.php" class="font-bold text-blue-600">Insights</a>
             <a href="pages.php" class="hover:text-blue-600">Seiten</a>
         <a href="modular_builder.php" class="hover:text-blue-600">Builder</a>
+        <a href="popup_builder.php" class="hover:text-blue-600">Popups</a>
             <a href="templates.php" class="hover:text-blue-600">Templates</a>
         </nav>
     </header>

--- a/admin/kategorien.php
+++ b/admin/kategorien.php
@@ -64,6 +64,7 @@ $kategorien = $pdo->query("SELECT * FROM kategorien ORDER BY name")->fetchAll(PD
             <a href="insights.php" class="hover:text-blue-600">Insights</a>
             <a href="pages.php" class="hover:text-blue-600">Seiten</a>
         <a href="modular_builder.php" class="hover:text-blue-600">Builder</a>
+        <a href="popup_builder.php" class="hover:text-blue-600">Popups</a>
             <a href="templates.php" class="hover:text-blue-600">Templates</a>
         </nav>
     </header>

--- a/admin/modular_builder.php
+++ b/admin/modular_builder.php
@@ -57,6 +57,7 @@ foreach ($pdo->query('SELECT slug, title FROM builder_pages ORDER BY title') as 
         <a href="dashboard.php" class="hover:text-blue-600">Dashboard</a>
         <a href="pages.php" class="hover:text-blue-600">Seiten</a>
         <a href="modular_builder.php" class="font-bold text-blue-600">Builder</a>
+        <a href="popup_builder.php" class="hover:text-blue-600">Popups</a>
     </nav>
 </header>
 <main class="max-w-5xl mx-auto px-4 py-10">

--- a/admin/page_builder.php
+++ b/admin/page_builder.php
@@ -54,6 +54,7 @@ if($_SERVER['REQUEST_METHOD']==='POST' && !$action){
         <a href="dashboard.php" class="hover:text-blue-600">Dashboard</a>
         <a href="pages.php" class="font-bold text-blue-600">Seiten</a>
         <a href="modular_builder.php" class="hover:text-blue-600">Builder</a>
+        <a href="popup_builder.php" class="hover:text-blue-600">Popups</a>
     </nav>
 </header>
 <main class="max-w-5xl mx-auto px-4 py-10">

--- a/admin/pages.php
+++ b/admin/pages.php
@@ -36,6 +36,7 @@ $pages = $pdo->query("SELECT * FROM pages ORDER BY id")->fetchAll(PDO::FETCH_ASS
         <a href="insights.php" class="hover:text-blue-600">Insights</a>
         <a href="pages.php" class="font-bold text-blue-600">Seiten</a>
         <a href="modular_builder.php" class="hover:text-blue-600">Builder</a>
+        <a href="popup_builder.php" class="hover:text-blue-600">Popups</a>
         <a href="customize.php" class="hover:text-blue-600">Website bearbeiten</a>
         <a href="templates.php" class="hover:text-blue-600">Templates</a>
     </nav>

--- a/admin/popup_builder.php
+++ b/admin/popup_builder.php
@@ -1,0 +1,138 @@
+<?php
+session_start();
+if(!isset($_SESSION['admin'])){header('Location: ../login.php');exit;}
+require '../inc/db.php';
+require '../pagebuilder/builder.php';
+
+$id = isset($_GET['id']) ? intval($_GET['id']) : 0;
+$popup = ['title'=>'','slug'=>'','layout'=>'','triggers'=>['delay'=>'','exit'=>0,'scroll'=>'','button'=>''],'pages'=>[]];
+if($id){
+    $stmt=$pdo->prepare('SELECT * FROM builder_popups WHERE id=?');
+    $stmt->execute([$id]);
+    if($row=$stmt->fetch(PDO::FETCH_ASSOC)){
+        $popup['title']=$row['title'];
+        $popup['slug']=$row['slug'];
+        $d=json_decode($row['layout'],true);$popup['layout']=$d['html']??'';
+        $popup['triggers']=$row['triggers']?json_decode($row['triggers'],true):[];
+        $popup['pages']=array_filter(explode(',',trim($row['pages'],',')));
+    }
+}
+
+$builder=new ModularPageBuilder();
+$widgets=$builder->loadWidgets(__DIR__.'/../pagebuilder/widgets');
+$popupList=[];
+foreach($pdo->query('SELECT id,title FROM builder_popups ORDER BY id') as $row){
+    $popupList[$row['id']]=$row['title'];
+}
+$pageOptions=['home'=>'Startseite'];
+foreach($pdo->query('SELECT id,name FROM kategorien ORDER BY name') as $row){
+    $pageOptions['category-'.$row['id']]='Kategorie: '.$row['name'];
+}
+foreach($pdo->query('SELECT slug,title FROM pages ORDER BY title') as $row){
+    $pageOptions[$row['slug']]=$row['title'];
+}
+foreach($pdo->query('SELECT slug,title FROM builder_pages ORDER BY title') as $row){
+    if(!isset($pageOptions[$row['slug']]))$pageOptions[$row['slug']]=$row['title'];
+}
+?>
+<!DOCTYPE html>
+<html lang="de">
+<head>
+<meta charset="UTF-8">
+<title>Popup Builder – nezbi Admin</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="https://cdn.tailwindcss.com"></script>
+<link href="https://fonts.googleapis.com/css?family=Inter:400,600&display=swap" rel="stylesheet">
+<script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
+<link rel="stylesheet" href="../pagebuilder/assets/builder.css">
+<link rel="stylesheet" href="../assets/animations.css">
+<style>body{font-family:'Inter',sans-serif;}</style>
+</head>
+<body class="bg-gray-50 text-gray-900">
+<header class="bg-white border-b shadow-sm">
+    <div class="max-w-5xl mx-auto flex justify-between items-center py-6 px-4">
+        <span class="text-2xl font-extrabold tracking-tight">nezbi Admin</span>
+        <div class="flex items-center">
+            <a href="logout.php" class="inline-block rounded-xl px-4 py-2 bg-blue-600 text-white font-medium hover:bg-blue-700 transition">Logout</a>
+        </div>
+    </div>
+    <nav class="flex space-x-8 max-w-5xl mx-auto px-4 pb-4">
+        <a href="dashboard.php" class="hover:text-blue-600">Dashboard</a>
+        <a href="pages.php" class="hover:text-blue-600">Seiten</a>
+        <a href="modular_builder.php" class="hover:text-blue-600">Builder</a>
+        <a href="popup_builder.php" class="font-bold text-blue-600">Popups</a>
+    </nav>
+</header>
+<main class="max-w-5xl mx-auto px-4 py-10">
+<h1 class="text-2xl font-bold mb-8">Popup Builder</h1>
+<div class="mb-4 space-y-2">
+    <div class="flex space-x-2">
+        <input type="text" id="pbPopupSearch" placeholder="Popup suchen..." class="flex-1 border px-2 py-1 rounded">
+        <select id="pbPopupSelect" class="border px-2 py-1 rounded w-60">
+            <?php foreach($popupList as $pid=>$title): ?>
+                <option value="<?= $pid ?>" <?= $pid==$id ? 'selected' : '' ?>><?= htmlspecialchars($title) ?></option>
+            <?php endforeach; ?>
+        </select>
+    </div>
+    <input type="text" id="pbTitle" value="<?= htmlspecialchars($popup['title']) ?>" placeholder="Titel" class="w-full border px-2 py-1 rounded">
+    <input type="text" id="pbSlug" value="<?= htmlspecialchars($popup['slug']) ?>" placeholder="Slug" class="w-full border px-2 py-1 rounded">
+    <label class="block">Verzögerung (Sek.) <input type="number" id="pbDelay" value="<?= htmlspecialchars($popup['triggers']['delay'] ?? '') ?>" class="border px-2 py-1 rounded w-full"></label>
+    <label class="block"><input type="checkbox" id="pbExit" <?= !empty($popup['triggers']['exit']) ? 'checked' : '' ?>> Exit-Intent</label>
+    <label class="block">Scroll % <input type="number" id="pbScroll" value="<?= htmlspecialchars($popup['triggers']['scroll'] ?? '') ?>" class="border px-2 py-1 rounded w-full"></label>
+    <input type="text" id="pbButton" value="<?= htmlspecialchars($popup['triggers']['button'] ?? '') ?>" placeholder="Button-Selector" class="w-full border px-2 py-1 rounded">
+    <label class="block">Seiten
+        <select id="pbPages" multiple size="5" class="border px-2 py-1 rounded w-full">
+            <?php foreach($pageOptions as $slug=>$title): ?>
+                <option value="<?= htmlspecialchars($slug) ?>" <?= in_array($slug,$popup['pages'])?'selected':'' ?>><?= htmlspecialchars($title) ?></option>
+            <?php endforeach; ?>
+        </select>
+    </label>
+    <button type="button" id="pbSave" class="px-4 py-2 bg-blue-600 text-white rounded">Speichern</button>
+    <div class="space-x-2 mt-2">
+        <button type="button" class="pb-bp-btn px-2 py-1 bg-gray-200 rounded" data-bp="desktop">Desktop</button>
+        <button type="button" class="pb-bp-btn px-2 py-1 bg-gray-200 rounded" data-bp="tablet">Tablet</button>
+        <button type="button" class="pb-bp-btn px-2 py-1 bg-gray-200 rounded" data-bp="mobile">Mobile</button>
+    </div>
+</div>
+<div class="flex">
+    <div class="w-60 mr-4 space-y-4" id="leftPanel">
+        <div id="pbConfigPanel" class="pb-config"></div>
+        <div class="text-sm space-y-2" id="widgetBar">
+            <?php foreach($widgets as $name=>$file): ?>
+                <button type="button" class="w-full px-2 py-1 bg-gray-200 rounded" data-widget="<?= htmlspecialchars($name) ?>"><?= htmlspecialchars($name) ?></button>
+            <?php endforeach; ?>
+        </div>
+    </div>
+    <div class="pb-canvas flex-1 border" id="builderCanvas" data-save-url="../popupbuilder/save_popup.php" data-load-url="<?= $id ? '../popupbuilder/load_popup.php?id='.$id : '' ?>" data-page-id="<?= $id ?>">
+        <?= $id ? '' : $popup['layout']; ?>
+    </div>
+</div>
+</main>
+<script src="../pagebuilder/assets/builder.js"></script>
+<script src="../assets/dynamic-widgets.js"></script>
+<script>
+document.addEventListener('DOMContentLoaded',()=>{
+  const sel=document.getElementById('pbPopupSelect');
+  if(sel){
+    sel.addEventListener('change',()=>{ const id=sel.value; window.location='popup_builder.php?id='+id; });
+  }
+  const saveBtn=document.getElementById('pbSave');
+  if(saveBtn){
+    saveBtn.addEventListener('click',async()=>{
+      const canvas=document.getElementById('builderCanvas');
+      const payload={
+        id:parseInt(canvas.dataset.pageId||0,10),
+        title:document.getElementById('pbTitle').value,
+        slug:document.getElementById('pbSlug').value,
+        layout:canvas.innerHTML,
+        triggers:{delay:document.getElementById('pbDelay').value,exit:document.getElementById('pbExit').checked?1:0,scroll:document.getElementById('pbScroll').value,button:document.getElementById('pbButton').value},
+        pages:Array.from(document.getElementById('pbPages').selectedOptions).map(o=>o.value)
+      };
+      const res=await fetch('../popupbuilder/save_popup.php',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(payload)});
+      if(res.ok){ const data=await res.json(); canvas.dataset.pageId=data.id; alert('Gespeichert'); } else { alert('Fehler beim Speichern'); }
+    });
+  }
+});
+</script>
+</body>
+</html>

--- a/admin/produkte.php
+++ b/admin/produkte.php
@@ -104,6 +104,7 @@ $kategorien = $pdo->query("SELECT * FROM kategorien ORDER BY name")->fetchAll(PD
             <a href="insights.php" class="hover:text-blue-600">Insights</a>
             <a href="pages.php" class="hover:text-blue-600">Seiten</a>
         <a href="modular_builder.php" class="hover:text-blue-600">Builder</a>
+        <a href="popup_builder.php" class="hover:text-blue-600">Popups</a>
             <a href="templates.php" class="hover:text-blue-600">Templates</a>
         </nav>
     </header>

--- a/admin/rabattcodes.php
+++ b/admin/rabattcodes.php
@@ -59,6 +59,7 @@ $codes = $pdo->query("SELECT * FROM rabattcodes ORDER BY id DESC")->fetchAll(PDO
             <a href="insights.php" class="hover:text-blue-600">Insights</a>
             <a href="pages.php" class="hover:text-blue-600">Seiten</a>
         <a href="modular_builder.php" class="hover:text-blue-600">Builder</a>
+        <a href="popup_builder.php" class="hover:text-blue-600">Popups</a>
             <a href="templates.php" class="hover:text-blue-600">Templates</a>
         </nav>
     </header>

--- a/admin/templates.php
+++ b/admin/templates.php
@@ -44,6 +44,7 @@ $templates=[
         <a href="insights.php" class="hover:text-blue-600">Insights</a>
         <a href="pages.php" class="hover:text-blue-600">Seiten</a>
         <a href="modular_builder.php" class="hover:text-blue-600">Builder</a>
+        <a href="popup_builder.php" class="hover:text-blue-600">Popups</a>
         <a href="customize.php" class="hover:text-blue-600">Website bearbeiten</a>
         <a href="templates.php" class="font-bold text-blue-600">Templates</a>
     </nav>

--- a/assets/popup.css
+++ b/assets/popup.css
@@ -1,0 +1,4 @@
+.pb-popup-overlay{position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.5);display:flex;align-items:center;justify-content:center;z-index:1000;}
+.pb-popup-overlay.hidden{display:none;}
+.pb-popup-content{position:relative;max-width:90%;max-height:90%;overflow:auto;background:#fff;padding:1rem;border-radius:0.5rem;}
+.pb-popup-close{position:absolute;top:0.25rem;right:0.25rem;background:none;border:none;font-size:1.5rem;cursor:pointer;}

--- a/assets/popups.js
+++ b/assets/popups.js
@@ -1,0 +1,21 @@
+(function(){
+  function initPopup(p){
+    const overlay=document.createElement('div');
+    overlay.className='pb-popup-overlay hidden';
+    overlay.innerHTML='<div class="pb-popup-content">'+p.html+'<button class="pb-popup-close" type="button">\u00d7</button></div>';
+    document.body.appendChild(overlay);
+    const closeBtn=overlay.querySelector('.pb-popup-close');
+    closeBtn.addEventListener('click',()=>overlay.classList.add('hidden'));
+    function open(){ overlay.classList.remove('hidden'); if(window.initWidgetAnimations) window.initWidgetAnimations(); }
+    const t=p.triggers||{};
+    if(t.delay){ setTimeout(open, parseInt(t.delay,10)*1000); }
+    if(t.exit){ const handler=e=>{ if(e.clientY<=0){ open(); document.removeEventListener('mouseout',handler); } }; document.addEventListener('mouseout',handler); }
+    if(t.scroll){ const sc=parseFloat(t.scroll); const sfunc=()=>{ const perc=(window.scrollY+window.innerHeight)/document.documentElement.scrollHeight*100; if(perc>=sc){ open(); window.removeEventListener('scroll',sfunc); } }; window.addEventListener('scroll',sfunc); }
+    if(t.button){ document.querySelectorAll(t.button).forEach(btn=>btn.addEventListener('click',open)); }
+  }
+  async function loadPopups(slug){
+    if(!slug) return; const res=await fetch('/popupbuilder/load_popups.php?slug='+encodeURIComponent(slug));
+    if(!res.ok) return; const data=await res.json(); data.forEach(initPopup);
+  }
+  document.addEventListener('DOMContentLoaded',()=>{ if(window.currentSlug!==undefined){ loadPopups(window.currentSlug); } });
+})();

--- a/inc/db.php
+++ b/inc/db.php
@@ -36,7 +36,7 @@ try {
         $pdo->exec("CREATE TABLE IF NOT EXISTS produkte (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, beschreibung TEXT, preis REAL, rabatt REAL DEFAULT NULL, bild TEXT, menge INTEGER, aktiv INTEGER DEFAULT 1, kategorie_id INTEGER REFERENCES kategorien(id))");
         $pdo->exec("CREATE TABLE IF NOT EXISTS pages (id INTEGER PRIMARY KEY AUTOINCREMENT, slug TEXT UNIQUE, title TEXT, content TEXT, meta_title TEXT, meta_description TEXT, canonical_url TEXT, jsonld TEXT)");
         $pdo->exec("CREATE TABLE IF NOT EXISTS builder_pages (id INTEGER PRIMARY KEY AUTOINCREMENT, slug TEXT UNIQUE, title TEXT, layout TEXT)");
-        // Keine automatischen Standardkategorien anlegen, damit gelöschte
+        $pdo->exec("CREATE TABLE IF NOT EXISTS builder_popups (id INTEGER PRIMARY KEY AUTOINCREMENT, slug TEXT UNIQUE, title TEXT, layout TEXT, triggers TEXT, pages TEXT)");
         // Kategorien nicht wieder erscheinen
     }
 }
@@ -52,6 +52,7 @@ try {
     } else {
         $pdo->exec("CREATE TABLE IF NOT EXISTS pages (id INT AUTO_INCREMENT PRIMARY KEY, slug VARCHAR(200) UNIQUE, title VARCHAR(200), content TEXT, meta_title TEXT, meta_description TEXT, canonical_url TEXT, jsonld TEXT)");
         $pdo->exec("CREATE TABLE IF NOT EXISTS builder_pages (id INT AUTO_INCREMENT PRIMARY KEY, slug VARCHAR(200) UNIQUE, title VARCHAR(200), layout TEXT)");
+        $pdo->exec("CREATE TABLE IF NOT EXISTS builder_popups (id INT AUTO_INCREMENT PRIMARY KEY, slug VARCHAR(200) UNIQUE, title VARCHAR(200), layout TEXT, triggers TEXT, pages TEXT)");
     }
 }
 
@@ -76,3 +77,15 @@ ensureColumn($pdo, 'pages', 'meta_title', 'TEXT');
 ensureColumn($pdo, 'pages', 'meta_description', 'TEXT');
 ensureColumn($pdo, 'pages', 'canonical_url', 'TEXT');
 ensureColumn($pdo, 'pages', 'jsonld', 'TEXT');
+
+// Tabelle 'builder_popups' sicherstellen
+try {
+    $pdo->query("SELECT 1 FROM builder_popups LIMIT 1");
+} catch (PDOException $e) {
+    $driver = $pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
+    if ($driver === 'sqlite') {
+        $pdo->exec("CREATE TABLE IF NOT EXISTS builder_popups (id INTEGER PRIMARY KEY AUTOINCREMENT, slug TEXT UNIQUE, title TEXT, layout TEXT, triggers TEXT, pages TEXT)");
+    } else {
+        $pdo->exec("CREATE TABLE IF NOT EXISTS builder_popups (id INT AUTO_INCREMENT PRIMARY KEY, slug VARCHAR(200) UNIQUE, title VARCHAR(200), layout TEXT, triggers TEXT, pages TEXT)");
+    }
+}

--- a/index.php
+++ b/index.php
@@ -5,6 +5,7 @@ require 'inc/db.php';
 require_once 'inc/pagebuilder.php';
 require 'inc/settings.php';
 $siteSettings = load_settings();
+$currentSlug = 'home';
 require_once "inc/template.php";
 
 $builderLayout = null;

--- a/kategorie.php
+++ b/kategorie.php
@@ -8,6 +8,7 @@ $kategorie = $stmt->fetch();
 if (!$kategorie) { http_response_code(404); exit('Kategorie nicht gefunden.'); }
 $active = 'produkte';
 $pageTitle = htmlspecialchars($kategorie['name']) . ' – nezbi';
+$currentSlug = 'category-' . $id;
 $builderLayout = null;
 if (!isset($_GET['classic'])) {
     $builderLayout = get_builder_layout($pdo, 'category-' . $id);

--- a/page.php
+++ b/page.php
@@ -15,6 +15,7 @@ if (!$page) {
     exit;
 }
 $pageTitle = $page['meta_title'] ?: $page['title'];
+$currentSlug = $slug;
 $metaDescription = $page['meta_description'] ?? '';
 $canonicalUrl = $page['canonical_url'] ?? '';
 $jsonLd = $page['jsonld'] ?? '';

--- a/popupbuilder/load_popup.php
+++ b/popupbuilder/load_popup.php
@@ -1,0 +1,30 @@
+<?php
+session_start();
+if (!isset($_SESSION['admin'])) { http_response_code(403); exit('Forbidden'); }
+require __DIR__ . '/../inc/db.php';
+
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$slug = $_GET['slug'] ?? '';
+if ($id) {
+    $stmt = $pdo->prepare('SELECT * FROM builder_popups WHERE id=?');
+    $stmt->execute([$id]);
+} elseif ($slug !== '') {
+    $stmt = $pdo->prepare('SELECT * FROM builder_popups WHERE slug=?');
+    $stmt->execute([$slug]);
+} else {
+    http_response_code(400);
+    echo json_encode(['error' => 'missing']);
+    exit;
+}
+$popup = $stmt->fetch(PDO::FETCH_ASSOC);
+if (!$popup) { http_response_code(404); echo json_encode(['error'=>'not found']); exit; }
+$data = json_decode($popup['layout'], true);
+
+echo json_encode([
+    'id' => $popup['id'],
+    'title' => $popup['title'],
+    'slug' => $popup['slug'],
+    'layout' => $data['html'] ?? '',
+    'triggers' => $popup['triggers'] ? json_decode($popup['triggers'], true) : [],
+    'pages' => trim($popup['pages'], ',')
+]);

--- a/popupbuilder/load_popups.php
+++ b/popupbuilder/load_popups.php
@@ -1,0 +1,17 @@
+<?php
+require __DIR__ . '/../inc/db.php';
+$slug = $_GET['slug'] ?? '';
+$stmt = $pdo->prepare("SELECT * FROM builder_popups WHERE pages='' OR pages LIKE ?");
+$stmt->execute(['%,'. $slug .',%']);
+$rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+$out = [];
+foreach ($rows as $row) {
+    $data = json_decode($row['layout'], true);
+    $out[] = [
+        'id' => $row['id'],
+        'html' => $data['html'] ?? '',
+        'triggers' => $row['triggers'] ? json_decode($row['triggers'], true) : []
+    ];
+}
+header('Content-Type: application/json');
+echo json_encode($out);

--- a/popupbuilder/save_popup.php
+++ b/popupbuilder/save_popup.php
@@ -1,0 +1,30 @@
+<?php
+session_start();
+if (!isset($_SESSION['admin'])) { http_response_code(403); exit('Forbidden'); }
+require __DIR__ . '/../inc/db.php';
+
+$input = json_decode(file_get_contents('php://input'), true);
+if (!$input) { http_response_code(400); echo json_encode(['error'=>'invalid']); exit; }
+
+$title = $input['title'] ?? '';
+$slug = isset($input['slug']) ? preg_replace('/[^a-z0-9-]/','-', strtolower(trim($input['slug']))) : '';
+$layout = json_encode(['html' => $input['layout'] ?? ''], JSON_UNESCAPED_UNICODE);
+$triggers = json_encode($input['triggers'] ?? [], JSON_UNESCAPED_UNICODE);
+$pages = '';
+if (!empty($input['pages']) && is_array($input['pages'])) {
+    $clean = array_map(function($s){ return preg_replace('/[^a-z0-9-]/','-', strtolower(trim($s))); }, $input['pages']);
+    $clean = array_filter($clean);
+    if ($clean) $pages = ',' . implode(',', $clean) . ',';
+}
+$id = isset($input['id']) ? (int)$input['id'] : 0;
+
+if ($id > 0) {
+    $stmt = $pdo->prepare('UPDATE builder_popups SET title=?, slug=?, layout=?, triggers=?, pages=? WHERE id=?');
+    $stmt->execute([$title, $slug, $layout, $triggers, $pages, $id]);
+} else {
+    $stmt = $pdo->prepare('INSERT INTO builder_popups (title, slug, layout, triggers, pages) VALUES (?,?,?,?,?)');
+    $stmt->execute([$title, $slug, $layout, $triggers, $pages]);
+    $id = $pdo->lastInsertId();
+}
+
+echo json_encode(['id'=>$id]);

--- a/produkt.php
+++ b/produkt.php
@@ -6,6 +6,7 @@ $stmt->execute([$id]);
 $prod = $stmt->fetch();
 if (!$prod) { http_response_code(404); exit('Produkt nicht gefunden.'); }
 $pageTitle = htmlspecialchars($prod['name']) . ' – nezbi';
+$currentSlug = 'product-' . $id;
 include 'inc/header.php';
 ?>
     <div class="flex flex-col md:flex-row gap-8">

--- a/produkte.php
+++ b/produkte.php
@@ -2,6 +2,7 @@
 require 'inc/db.php';
 $active = 'produkte';
 $pageTitle = 'Produkte – nezbi';
+$currentSlug = 'products';
 $kats = $pdo->query("SELECT * FROM kategorien ORDER BY name")->fetchAll(PDO::FETCH_ASSOC);
 
 $sort = $_GET['sort'] ?? '';

--- a/sql/setup.sql
+++ b/sql/setup.sql
@@ -63,3 +63,12 @@ CREATE TABLE builder_pages (
     title VARCHAR(200),
     layout TEXT
 );
+
+CREATE TABLE builder_popups (
+    id INT PRIMARY KEY AUTO_INCREMENT,
+    slug VARCHAR(200) UNIQUE,
+    title VARCHAR(200),
+    layout TEXT,
+    triggers TEXT,
+    pages TEXT
+);

--- a/sql/setup_sqlite.sql
+++ b/sql/setup_sqlite.sql
@@ -61,3 +61,12 @@ CREATE TABLE builder_pages (
     title TEXT,
     layout TEXT
 );
+
+CREATE TABLE builder_popups (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    slug TEXT UNIQUE,
+    title TEXT,
+    layout TEXT,
+    triggers TEXT,
+    pages TEXT
+);

--- a/templates/footer.php
+++ b/templates/footer.php
@@ -4,6 +4,8 @@ require_once __DIR__.'/../inc/settings.php';
 $siteSettings = load_settings();
 ?>
 <footer class="py-10 text-center text-gray-400 text-xs"><?= htmlspecialchars($siteSettings['footer_text']) ?></footer>
+<script>var currentSlug = '<?= isset($currentSlug) ? htmlspecialchars($currentSlug) : '' ?>';</script>
 <script src="/assets/dynamic-widgets.js"></script>
+<script src="/assets/popups.js"></script>
 </body>
 </html>

--- a/templates/header.php
+++ b/templates/header.php
@@ -52,6 +52,7 @@ if (isset($pdo)) {
     ?>
     <link href="https://fonts.googleapis.com/css?family=<?= $fontLink ?>:400,600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/assets/animations.css">
+    <link rel="stylesheet" href="/assets/popup.css">
     <style>
       body { font-family: '<?= htmlspecialchars($font) ?>', sans-serif; background-color: var(--body-bg, #f9fafb); color: var(--text-color, #111827); }
       .fade-in { animation: fadeIn 0.6s ease-in-out; }

--- a/warenkorb.php
+++ b/warenkorb.php
@@ -3,6 +3,7 @@ session_start();
 require 'inc/db.php';
 $active = '';
 $pageTitle = 'Warenkorb – nezbi';
+$currentSlug = 'cart';
 if (!isset($_SESSION['cart'])) { $_SESSION['cart'] = []; }
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {


### PR DESCRIPTION
## Summary
- add popup builder admin page and JS
- add DB table `builder_popups`
- include popup assets and global slug variable
- enable editing of popup triggers and target pages
- add navigation link to popup builder in admin

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849a5f93e28832198ff461e00bd09bf