### PR TITLE
Add layout library with copy/paste support

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Ebenfalls neu ist ein modularer visueller Page Builder. Die zugehörigen Dateien
 
 Der Builder kann nun auch für bestehende Shop-Seiten wie die Startseite, Kategorien oder CMS-Seiten verwendet werden. Liegt für eine Seite ein Eintrag in `builder_pages` vor, ersetzt das dort gespeicherte Layout den regulären Inhalt. Über den Parameter `?classic=1` lässt sich jederzeit zum Standardlayout zurückkehren.
 
+Neu ist die Möglichkeit, einzelne Abschnitte oder Widgets zu kopieren und in andere Seiten einzufügen. Eigene Layouts können zudem als Vorlage gespeichert werden. Diese Vorlagen werden in einer Bibliothek verwaltet und lassen sich von dort in jede Seite einfügen.
+
 ## Globale Templates
 
 Im Verzeichnis `templates` liegen wiederverwendbare Abschnitte wie `header.php`, `footer.php` oder `cta.php`. Mit der Funktion `render_template()` aus `inc/template.php` lassen sich diese Bereiche auf beliebigen Seiten einbinden:

--- a/admin/layout_library.php
+++ b/admin/layout_library.php
@@ -1,0 +1,52 @@
+<?php
+session_start();
+if(!isset($_SESSION['admin'])){header('Location: ../login.php');exit;}
+require '../inc/db.php';
+if(isset($_GET['delete'])){
+    $id=intval($_GET['delete']);
+    $pdo->prepare('DELETE FROM builder_templates WHERE id=?')->execute([$id]);
+    header('Location: layout_library.php');
+    exit;
+}
+$templates=$pdo->query('SELECT id,name,html FROM builder_templates ORDER BY name')->fetchAll(PDO::FETCH_ASSOC);
+?>
+<!DOCTYPE html>
+<html lang="de">
+<head>
+<meta charset="UTF-8">
+<title>Vorlagenbibliothek – nezbi Admin</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="https://cdn.tailwindcss.com"></script>
+<link href="https://fonts.googleapis.com/css?family=Inter:400,600&display=swap" rel="stylesheet">
+<style>body{font-family:'Inter',sans-serif;}</style>
+</head>
+<body class="bg-gray-50 text-gray-900">
+<header class="bg-white border-b shadow-sm">
+    <div class="max-w-5xl mx-auto flex justify-between items-center py-6 px-4">
+        <span class="text-2xl font-extrabold tracking-tight">nezbi Admin</span>
+        <div class="flex items-center">
+            <a href="logout.php" class="inline-block rounded-xl px-4 py-2 bg-blue-600 text-white font-medium hover:bg-blue-700 transition">Logout</a>
+        </div>
+    </div>
+    <nav class="flex space-x-8 max-w-5xl mx-auto px-4 pb-4">
+        <a href="dashboard.php" class="hover:text-blue-600">Dashboard</a>
+        <a href="pages.php" class="hover:text-blue-600">Seiten</a>
+        <a href="modular_builder.php" class="hover:text-blue-600">Builder</a>
+        <a href="popup_builder.php" class="hover:text-blue-600">Popups</a>
+        <a href="layout_library.php" class="font-bold text-blue-600">Layouts</a>
+    </nav>
+</header>
+<main class="max-w-5xl mx-auto px-4 py-10 space-y-6">
+<h1 class="text-2xl font-bold mb-8">Vorlagenbibliothek</h1>
+<?php foreach($templates as $tpl): ?>
+    <div class="border rounded-xl p-4 bg-white shadow flex justify-between items-center mb-4">
+        <div>
+            <h3 class="font-semibold mb-2"><?=htmlspecialchars($tpl['name'])?></h3>
+            <div class="border p-2 mb-2"><?= $tpl['html'] ?></div>
+        </div>
+        <a href="?delete=<?= $tpl['id'] ?>" class="text-red-600" onclick="return confirm('Vorlage löschen?');">Löschen</a>
+    </div>
+<?php endforeach; ?>
+</main>
+</body>
+</html>

--- a/admin/modular_builder.php
+++ b/admin/modular_builder.php
@@ -58,6 +58,7 @@ foreach ($pdo->query('SELECT slug, title FROM builder_pages ORDER BY title') as 
         <a href="pages.php" class="hover:text-blue-600">Seiten</a>
         <a href="modular_builder.php" class="font-bold text-blue-600">Builder</a>
         <a href="popup_builder.php" class="hover:text-blue-600">Popups</a>
+        <a href="layout_library.php" class="hover:text-blue-600">Layouts</a>
     </nav>
 </header>
 <main class="max-w-5xl mx-auto px-4 py-10">
@@ -83,6 +84,12 @@ foreach ($pdo->query('SELECT slug, title FROM builder_pages ORDER BY title') as 
 <div class="flex">
     <div class="w-60 mr-4 space-y-4" id="leftPanel">
         <div id="pbConfigPanel" class="pb-config"></div>
+        <button type="button" id="pbPaste" class="w-full px-2 py-1 bg-gray-200 rounded">Einfügen</button>
+        <div class="space-y-2 text-sm" id="templateTools">
+            <select id="pbTemplateSelect" class="border px-2 py-1 rounded w-full"></select>
+            <button type="button" id="pbInsertTemplate" class="w-full px-2 py-1 bg-gray-200 rounded">Vorlage einfügen</button>
+            <a href="layout_library.php" class="block text-center text-blue-600">Vorlagen verwalten</a>
+        </div>
         <div class="text-sm space-y-2" id="widgetBar">
             <?php foreach($widgets as $name => $file): ?>
                 <button type="button" class="w-full px-2 py-1 bg-gray-200 rounded" data-widget="<?= htmlspecialchars($name) ?>"><?= htmlspecialchars($name) ?></button>

--- a/admin/popup_builder.php
+++ b/admin/popup_builder.php
@@ -61,6 +61,7 @@ foreach($pdo->query('SELECT slug,title FROM builder_pages ORDER BY title') as $r
         <a href="pages.php" class="hover:text-blue-600">Seiten</a>
         <a href="modular_builder.php" class="hover:text-blue-600">Builder</a>
         <a href="popup_builder.php" class="font-bold text-blue-600">Popups</a>
+        <a href="layout_library.php" class="hover:text-blue-600">Layouts</a>
     </nav>
 </header>
 <main class="max-w-5xl mx-auto px-4 py-10">

--- a/inc/db.php
+++ b/inc/db.php
@@ -89,3 +89,15 @@ try {
         $pdo->exec("CREATE TABLE IF NOT EXISTS builder_popups (id INT AUTO_INCREMENT PRIMARY KEY, slug VARCHAR(200) UNIQUE, title VARCHAR(200), layout TEXT, triggers TEXT, pages TEXT)");
     }
 }
+
+// Tabelle 'builder_templates' sicherstellen
+try {
+    $pdo->query("SELECT 1 FROM builder_templates LIMIT 1");
+} catch (PDOException $e) {
+    $driver = $pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
+    if ($driver === 'sqlite') {
+        $pdo->exec("CREATE TABLE IF NOT EXISTS builder_templates (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, html TEXT)");
+    } else {
+        $pdo->exec("CREATE TABLE IF NOT EXISTS builder_templates (id INT AUTO_INCREMENT PRIMARY KEY, name VARCHAR(200), html TEXT)");
+    }
+}

--- a/pagebuilder/assets/builder.css
+++ b/pagebuilder/assets/builder.css
@@ -26,7 +26,9 @@
   padding: 0.125rem 0.25rem;
   font-size: 0.75rem;
   border-radius: 0.25rem;
+  margin-left: 0.25rem;
 }
+.pb-controls button:first-child { margin-left: 0; }
 
 /* Konfigurationspanel */
 .pb-config-overlay {

--- a/pagebuilder/delete_template.php
+++ b/pagebuilder/delete_template.php
@@ -1,0 +1,10 @@
+<?php
+session_start();
+if(!isset($_SESSION['admin'])){ http_response_code(403); exit('Forbidden'); }
+require __DIR__.'/../inc/db.php';
+$id=isset($_POST['id'])?intval($_POST['id']):(isset($_GET['id'])?intval($_GET['id']):0);
+if($id){
+    $stmt=$pdo->prepare('DELETE FROM builder_templates WHERE id=?');
+    $stmt->execute([$id]);
+}
+echo json_encode(['success'=>true]);

--- a/pagebuilder/get_template.php
+++ b/pagebuilder/get_template.php
@@ -1,0 +1,10 @@
+<?php
+session_start();
+if(!isset($_SESSION['admin'])){ http_response_code(403); exit('Forbidden'); }
+require __DIR__.'/../inc/db.php';
+$id=isset($_GET['id'])?intval($_GET['id']):0;
+$stmt=$pdo->prepare('SELECT html FROM builder_templates WHERE id=?');
+$stmt->execute([$id]);
+$html=$stmt->fetchColumn();
+if($html===false){ http_response_code(404); echo json_encode(['error'=>'not found']); }
+else echo json_encode(['html'=>$html]);

--- a/pagebuilder/list_templates.php
+++ b/pagebuilder/list_templates.php
@@ -1,0 +1,6 @@
+<?php
+session_start();
+if(!isset($_SESSION['admin'])){ http_response_code(403); exit('Forbidden'); }
+require __DIR__.'/../inc/db.php';
+$rows=$pdo->query('SELECT id,name FROM builder_templates ORDER BY name')->fetchAll(PDO::FETCH_ASSOC);
+echo json_encode($rows);

--- a/pagebuilder/save_template.php
+++ b/pagebuilder/save_template.php
@@ -1,0 +1,13 @@
+<?php
+session_start();
+if(!isset($_SESSION['admin'])){ http_response_code(403); exit('Forbidden'); }
+require __DIR__.'/../inc/db.php';
+$input=json_decode(file_get_contents('php://input'),true);
+if(!$input || !isset($input['name']) || !isset($input['html'])){
+    http_response_code(400);
+    echo json_encode(['error'=>'invalid']);
+    exit;
+}
+$stmt=$pdo->prepare('INSERT INTO builder_templates (name,html) VALUES (?,?)');
+$stmt->execute([$input['name'],$input['html']]);
+echo json_encode(['id'=>$pdo->lastInsertId()]);

--- a/sql/setup.sql
+++ b/sql/setup.sql
@@ -72,3 +72,10 @@ CREATE TABLE builder_popups (
     triggers TEXT,
     pages TEXT
 );
+
+# Vorlagen für wiederverwendbare Layouts
+CREATE TABLE builder_templates (
+    id INT PRIMARY KEY AUTO_INCREMENT,
+    name VARCHAR(200),
+    html TEXT
+);

--- a/sql/setup_sqlite.sql
+++ b/sql/setup_sqlite.sql
@@ -70,3 +70,10 @@ CREATE TABLE builder_popups (
     triggers TEXT,
     pages TEXT
 );
+
+# Vorlagen für wiederverwendbare Layouts
+CREATE TABLE builder_templates (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT,
+    html TEXT
+);


### PR DESCRIPTION
## Summary
- support cross-page copy/paste of builder elements
- allow saving elements as templates
- provide template library management page
- include template API endpoints
- update DB setup for `builder_templates`
- document new features

## Testing
- `php` linting *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849aeee4c708321bffac5710babf4f2