### PR TITLE
Fix builder 500 errors on older PHP

### DIFF
--- a/inc/db.php
+++ b/inc/db.php
@@ -57,7 +57,7 @@ try {
 }
 
 // Sicherstellen, dass neue SEO-Spalten vorhanden sind
-function ensureColumn(PDO $pdo, string $table, string $column, string $type) {
+function ensureColumn(PDO $pdo, $table, $column, $type) {
     $driver = $pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
     try {
         if ($driver === 'sqlite') {

--- a/inc/pagebuilder.php
+++ b/inc/pagebuilder.php
@@ -1,5 +1,5 @@
 <?php
-function get_builder_layout(PDO $pdo, string $slug): ?string {
+function get_builder_layout(PDO $pdo, $slug) {
     try {
         $stmt = $pdo->prepare('SELECT layout FROM builder_pages WHERE slug=?');
         $stmt->execute([$slug]);

--- a/inc/template.php
+++ b/inc/template.php
@@ -1,5 +1,5 @@
 <?php
-function render_template(string $name, array $vars = []) {
+function render_template($name, $vars = []) {
     $file = __DIR__ . '/../templates/' . $name . '.php';
     if (!file_exists($file)) {
         return;

--- a/pagebuilder/builder.php
+++ b/pagebuilder/builder.php
@@ -6,7 +6,7 @@
  */
 
 class ModularPageBuilder {
-    public function loadWidgets(string $dir): array {
+    public function loadWidgets($dir) {
         $widgets = [];
         foreach (glob(rtrim($dir, '/') . '/*.php') as $file) {
             $widgets[basename($file, '.php')] = $file;
@@ -14,7 +14,7 @@ class ModularPageBuilder {
         return $widgets;
     }
 
-    public function renderWidget(string $widget, array $data = []): string {
+    public function renderWidget($widget, $data = []) {
         if (!file_exists($widget)) {
             return '';
         }


### PR DESCRIPTION
## Summary
- remove PHP 7+ type hints in pagebuilder and inc utilities

## Testing
- `find . -name '*.php' -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_6849c99e545c83219789a49fb332d026