### PR TITLE
Fix builder 500 error with SQLite

### DIFF
--- a/sql/setup_sqlite.sql
+++ b/sql/setup_sqlite.sql
@@ -71,7 +71,7 @@ CREATE TABLE builder_popups (
     pages TEXT
 );
 
-# Vorlagen für wiederverwendbare Layouts
+-- Vorlagen für wiederverwendbare Layouts
 CREATE TABLE builder_templates (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     name TEXT,


### PR DESCRIPTION
## Summary
- fix SQLite comment style in setup SQL

## Testing
- `php -l` on PHP files

------
https://chatgpt.com/codex/tasks/task_e_6849cba074dc8321b00855f3c5877d90