### PR TITLE
Fix builder header output

### DIFF
--- a/pagebuilder/builder.php
+++ b/pagebuilder/builder.php
@@ -24,4 +24,4 @@ class ModularPageBuilder {
         return ob_get_clean();
     }
 }
-?>
+


### PR DESCRIPTION
## Summary
- fix header warnings by removing closing PHP tag from pagebuilder/builder.php

## Testing
- `php -l ../pagebuilder/builder.php`
- `php -l ../pagebuilder/fetch_widget.php`

------
https://chatgpt.com/codex/tasks/task_e_6849fee1c8c4832193c43a71031ccaec