### PR TITLE
Add debugging lines to builder.php

### DIFF
--- a/pagebuilder/builder.php
+++ b/pagebuilder/builder.php
@@ -1,4 +1,7 @@
 <?php
+ini_set('display_errors', 1);
+ini_set('display_startup_errors', 1);
+error_reporting(E_ALL);
 /**
  * Einfacher Modularer Page Builder
  *


### PR DESCRIPTION
## Summary
- enable PHP error reporting in `pagebuilder/builder.php`

## Testing
- `php -l pagebuilder/builder.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a063b37148321abfbc9dbc4e15166