### PR TITLE
Fix headers already sent by removing closing tags

### DIFF
--- a/inc/footer.php
+++ b/inc/footer.php
@@ -1,4 +1,3 @@
 <?php
 require_once __DIR__ . '/template.php';
 render_template('footer', get_defined_vars());
-?>

--- a/inc/header.php
+++ b/inc/header.php
@@ -1,4 +1,3 @@
 <?php
 require_once __DIR__ . '/template.php';
 render_template('header', get_defined_vars());
-?>

--- a/inc/pagebuilder.php
+++ b/inc/pagebuilder.php
@@ -13,4 +13,3 @@ function get_builder_layout(PDO $pdo, $slug) {
     }
     return null;
 }
-?>

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -38,4 +38,3 @@ function save_settings($settings){
     }
     file_put_contents($file, json_encode($settings, JSON_PRETTY_PRINT));
 }
-?>

--- a/inc/template.php
+++ b/inc/template.php
@@ -7,4 +7,3 @@ function render_template($name, $vars = []) {
     extract($vars, EXTR_SKIP);
     include $file;
 }
-?>


### PR DESCRIPTION
## Summary
- remove stray `?>` from helper includes

## Testing
- `php -l inc/footer.php`
- `php -l inc/header.php`
- `php -l inc/template.php`
- `php -l inc/pagebuilder.php`
- `php -l inc/settings.php`


------
https://chatgpt.com/codex/tasks/task_e_684b2d185b288321bc540bda5a94511e