### PR TITLE
Style widget buttons

### DIFF
--- a/admin/modular_builder.php
+++ b/admin/modular_builder.php
@@ -98,8 +98,11 @@ foreach ($pdo->query('SELECT slug, title FROM builder_pages ORDER BY title') as 
             <a href="layout_library.php" class="block text-center text-blue-600">Vorlagen verwalten</a>
         </div>
         <div class="text-sm space-y-2" id="widgetBar">
-            <?php foreach($widgets as $name => $file): ?>
-                <button type="button" class="pb-btn pb-btn-secondary w-full" data-widget="<?= htmlspecialchars($name) ?>"><?= htmlspecialchars($name) ?></button>
+            <?php foreach($widgets as $name => $file):
+                $type = in_array($name, ['section','column']) ? 'container' : 'content'; ?>
+                <button type="button" class="pb-widget-btn" data-widget="<?= htmlspecialchars($name) ?>" data-type="<?= $type ?>">
+                    <?= htmlspecialchars($name) ?>
+                </button>
             <?php endforeach; ?>
         </div>
     </div>

--- a/admin/popup_builder.php
+++ b/admin/popup_builder.php
@@ -99,8 +99,11 @@ foreach($pdo->query('SELECT slug,title FROM builder_pages ORDER BY title') as $r
     <div class="w-60 mr-4 space-y-4" id="leftPanel">
         <div id="pbConfigPanel" class="pb-config"></div>
         <div class="text-sm space-y-2" id="widgetBar">
-            <?php foreach($widgets as $name=>$file): ?>
-                <button type="button" class="w-full px-2 py-1 bg-gray-200 rounded" data-widget="<?= htmlspecialchars($name) ?>"><?= htmlspecialchars($name) ?></button>
+            <?php foreach($widgets as $name=>$file):
+                $type = in_array($name, ['section','column']) ? 'container' : 'content'; ?>
+                <button type="button" class="pb-widget-btn" data-widget="<?= htmlspecialchars($name) ?>" data-type="<?= $type ?>">
+                    <?= htmlspecialchars($name) ?>
+                </button>
             <?php endforeach; ?>
         </div>
     </div>

--- a/pagebuilder/assets/builder.css
+++ b/pagebuilder/assets/builder.css
@@ -114,3 +114,21 @@
 @media (max-width: 640px) {
   .pb-builder-container { padding-left: 1rem; padding-right: 1rem; }
 }
+
+/* Widget Buttons */
+.pb-widget-btn {
+  display: block;
+  width: 100%;
+  height: 2.25rem;
+  line-height: 1.25rem;
+  font-size: 0.875rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 0.375rem;
+  padding: 0.5rem;
+  box-sizing: border-box;
+  transition: background 0.2s;
+}
+.pb-widget-btn[data-type="container"] { background: #f3f4f6; }
+.pb-widget-btn[data-type="content"] { background: #fff; }
+.pb-widget-btn[data-type="container"]:hover { background: #e2e8f0; }
+.pb-widget-btn[data-type="content"]:hover { background: #f8fafc; }


### PR DESCRIPTION
## Summary
- unify widget button look in builder screens
- add pb-widget-btn style
- make buttons display container vs content type

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b407468a88321b0561d56b123782a