### PR TITLE
Fix header warning when loading widgets

### DIFF
--- a/admin/logout.php
+++ b/admin/logout.php
@@ -3,4 +3,3 @@ session_start();
 session_destroy();
 header('Location: ../login.php');
 exit;
-?>

--- a/debug.php
+++ b/debug.php
@@ -1,0 +1,5 @@
+<?php
+ini_set('display_errors', 1);
+ini_set('display_startup_errors', 1);
+error_reporting(E_ALL);
+?>

--- a/pagebuilder/builder.php
+++ b/pagebuilder/builder.php
@@ -1,7 +1,5 @@
 <?php
-ini_set('display_errors', 1);
-ini_set('display_startup_errors', 1);
-error_reporting(E_ALL);
+require_once __DIR__ . "/../debug.php";
 /**
  * Einfacher Modularer Page Builder
  *

--- a/pagebuilder/widgets/accordion.php
+++ b/pagebuilder/widgets/accordion.php
@@ -1,3 +1,5 @@
+<?php
+?>
 <div class="pb-accordion">
   <div class="pb-acc-item">
     <button class="pb-acc-header">Eintrag 1</button>

--- a/pagebuilder/widgets/button.php
+++ b/pagebuilder/widgets/button.php
@@ -1,1 +1,3 @@
+<?php
+?>
 <a href="#" class="pb-button px-4 py-2 bg-blue-600 text-white rounded">Button</a>

--- a/pagebuilder/widgets/card.php
+++ b/pagebuilder/widgets/card.php
@@ -1,3 +1,5 @@
+<?php
+?>
 <div class="pb-card border rounded p-4">
   <h3 class="font-semibold mb-2">Card Titel</h3>
   <p>Ein kleiner Beschreibungstext.</p>

--- a/pagebuilder/widgets/category_list.php
+++ b/pagebuilder/widgets/category_list.php
@@ -1,1 +1,3 @@
+<?php
+?>
 <div class="pb-category-list" data-limit="10">Kategorien werden geladen...</div>

--- a/pagebuilder/widgets/column.php
+++ b/pagebuilder/widgets/column.php
@@ -1,3 +1,5 @@
+<?php
+?>
 <div class="pb-column grid grid-cols-2 gap-4">
   <div>Spalte 1</div>
   <div>Spalte 2</div>

--- a/pagebuilder/widgets/countdown.php
+++ b/pagebuilder/widgets/countdown.php
@@ -1,3 +1,5 @@
+<?php
+?>
 <div class="pb-countdown" data-date="2030-01-01T00:00:00">
   <span class="pb-countdown-display">00:00:00:00</span>
 </div>

--- a/pagebuilder/widgets/heading.php
+++ b/pagebuilder/widgets/heading.php
@@ -1,1 +1,3 @@
+<?php
+?>
 <h2 class="pb-heading text-xl font-bold">Überschrift</h2>

--- a/pagebuilder/widgets/image.php
+++ b/pagebuilder/widgets/image.php
@@ -1,1 +1,3 @@
+<?php
+?>
 <img src="https://via.placeholder.com/300x200" alt="Bild" class="pb-image" />

--- a/pagebuilder/widgets/list.php
+++ b/pagebuilder/widgets/list.php
@@ -1,3 +1,5 @@
+<?php
+?>
 <ul class="pb-list list-disc pl-6">
   <li>Listelement 1</li>
   <li>Listelement 2</li>

--- a/pagebuilder/widgets/product_grid.php
+++ b/pagebuilder/widgets/product_grid.php
@@ -1,1 +1,3 @@
+<?php
+?>
 <div class="pb-product-grid" data-category="" data-limit="6">Produkt-Grid wird geladen...</div>

--- a/pagebuilder/widgets/section.php
+++ b/pagebuilder/widgets/section.php
@@ -1,1 +1,3 @@
+<?php
+?>
 <section class="pb-section p-4 bg-gray-100">Section Inhalt</section>

--- a/pagebuilder/widgets/slider.php
+++ b/pagebuilder/widgets/slider.php
@@ -1,3 +1,5 @@
+<?php
+?>
 <div class="pb-slider">
   <div class="pb-slide"><img src="https://via.placeholder.com/600x300?text=Bild+1" alt="Bild 1"></div>
   <div class="pb-slide" style="display:none"><img src="https://via.placeholder.com/600x300?text=Bild+2" alt="Bild 2"></div>

--- a/pagebuilder/widgets/spacer.php
+++ b/pagebuilder/widgets/spacer.php
@@ -1,1 +1,3 @@
+<?php
+?>
 <div class="pb-spacer my-4"></div>

--- a/pagebuilder/widgets/tabs.php
+++ b/pagebuilder/widgets/tabs.php
@@ -1,3 +1,5 @@
+<?php
+?>
 <div class="pb-tabs">
   <div class="pb-tab-headers">
     <button data-tab="0" class="active">Tab 1</button>

--- a/pagebuilder/widgets/text.php
+++ b/pagebuilder/widgets/text.php
@@ -1,1 +1,3 @@
+<?php
+?>
 <div class="pb-text">Hier steht ein einfacher Text.</div>

--- a/pagebuilder/widgets/video.php
+++ b/pagebuilder/widgets/video.php
@@ -1,3 +1,5 @@
+<?php
+?>
 <div class="pb-video">
   <iframe src="https://www.youtube.com/embed/dQw4w9WgXcQ" frameborder="0" allowfullscreen class="w-full h-48"></iframe>
 </div>

--- a/templates/footer.php
+++ b/templates/footer.php
@@ -1,3 +1,5 @@
+<?php
+?>
 </main>
 <?php
 require_once __DIR__.'/../inc/settings.php';


### PR DESCRIPTION
## Summary
- prevent early HTML output by adding an initial PHP open/close tag to each widget
- centralize debug settings in a new `debug.php`
- include `debug.php` from the page builder
- ensure footer template starts with PHP
- remove closing tag from `admin/logout.php`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b679ba4488321bbb7d2a20f1e33d3