### PR TITLE
Centralize debug settings

### DIFF
--- a/debug.php
+++ b/debug.php
@@ -1,6 +1,0 @@
-<?php
-function enable_debug() {
-    ini_set('display_errors', 1);
-    ini_set('display_startup_errors', 1);
-    error_reporting(E_ALL);
-}

--- a/inc/debug.php
+++ b/inc/debug.php
@@ -1,0 +1,5 @@
+<?php
+// Enable error reporting for development
+ini_set('display_errors', 1);
+ini_set('display_startup_errors', 1);
+error_reporting(E_ALL);


### PR DESCRIPTION
## Summary
- move debugging settings into `inc/debug.php`
- remove old `debug.php`

## Testing
- `php` interpreter not found; could not run syntax check

------
https://chatgpt.com/codex/tasks/task_e_684c46a2ef408321949ed85655893001