### PR TITLE
Fix debug output leakage in page builder

### DIFF
--- a/inc/debug.php
+++ b/inc/debug.php
@@ -1,5 +1,7 @@
 <?php
-// Enable error reporting for development
-ini_set('display_errors', 1);
-ini_set('display_startup_errors', 1);
-error_reporting(E_ALL);
+// Enable error reporting when APP_DEBUG environment variable is set
+if (getenv('APP_DEBUG')) {
+    ini_set('display_errors', 1);
+    ini_set('display_startup_errors', 1);
+    error_reporting(E_ALL);
+}

--- a/pagebuilder/builder.php
+++ b/pagebuilder/builder.php
@@ -1,4 +1,8 @@
 <?php
+// Optional debugging
+if (file_exists(__DIR__ . '/../inc/debug.php')) {
+    require_once __DIR__ . '/../inc/debug.php';
+}
 /**
  * Einfacher Modularer Page Builder
  *

--- a/pagebuilder/fetch_widget.php
+++ b/pagebuilder/fetch_widget.php
@@ -1,4 +1,7 @@
 <?php
+if (file_exists(__DIR__ . '/../inc/debug.php')) {
+    require_once __DIR__ . '/../inc/debug.php';
+}
 require __DIR__ . '/builder.php';
 
 $name = basename($_GET['name'] ?? '');


### PR DESCRIPTION
## Summary
- guard debug settings behind `APP_DEBUG` env flag
- optionally include debug settings in `builder.php` and `fetch_widget.php`

## Testing
- `php -l inc/debug.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c4aa1a4688321b11a26dd15efeb1f