### PR TITLE
Fix builder header warnings

### DIFF
--- a/pagebuilder/builder.php
+++ b/pagebuilder/builder.php
@@ -1,4 +1,5 @@
 <?php
+ob_start();
 // Optional debugging
 if (file_exists(__DIR__ . '/../inc/debug.php')) {
     require_once __DIR__ . '/../inc/debug.php';
@@ -28,4 +29,5 @@ class ModularPageBuilder {
         return ob_get_clean();
     }
 }
+ob_end_flush();
 

--- a/pagebuilder/fetch_widget.php
+++ b/pagebuilder/fetch_widget.php
@@ -1,4 +1,5 @@
 <?php
+ob_start();
 if (file_exists(__DIR__ . '/../inc/debug.php')) {
     require_once __DIR__ . '/../inc/debug.php';
 }
@@ -19,4 +20,5 @@ if (!file_exists($file)) {
 $builder = new ModularPageBuilder();
 header('Content-Type: text/html; charset=UTF-8');
 echo $builder->renderWidget($file);
+ob_end_flush();
 

--- a/pagebuilder/widgets/accordion.php
+++ b/pagebuilder/widgets/accordion.php
@@ -1,4 +1,5 @@
 <?php
+ob_start();
 ?>
 <div class="pb-accordion">
   <div class="pb-acc-item">
@@ -30,3 +31,4 @@
     });
   });
 })();</script>
+<?php ob_end_flush(); ?>

--- a/pagebuilder/widgets/button.php
+++ b/pagebuilder/widgets/button.php
@@ -1,3 +1,5 @@
 <?php
+ob_start();
 ?>
 <a href="#" class="pb-button px-4 py-2 bg-blue-600 text-white rounded">Button</a>
+<?php ob_end_flush(); ?>

--- a/pagebuilder/widgets/card.php
+++ b/pagebuilder/widgets/card.php
@@ -1,6 +1,8 @@
 <?php
+ob_start();
 ?>
 <div class="pb-card border rounded p-4">
   <h3 class="font-semibold mb-2">Card Titel</h3>
   <p>Ein kleiner Beschreibungstext.</p>
 </div>
+<?php ob_end_flush(); ?>

--- a/pagebuilder/widgets/category_list.php
+++ b/pagebuilder/widgets/category_list.php
@@ -1,3 +1,5 @@
 <?php
+ob_start();
 ?>
 <div class="pb-category-list" data-limit="10">Kategorien werden geladen...</div>
+<?php ob_end_flush(); ?>

--- a/pagebuilder/widgets/column.php
+++ b/pagebuilder/widgets/column.php
@@ -1,6 +1,8 @@
 <?php
+ob_start();
 ?>
 <div class="pb-column grid grid-cols-2 gap-4">
   <div>Spalte 1</div>
   <div>Spalte 2</div>
 </div>
+<?php ob_end_flush(); ?>

--- a/pagebuilder/widgets/countdown.php
+++ b/pagebuilder/widgets/countdown.php
@@ -1,4 +1,5 @@
 <?php
+ob_start();
 ?>
 <div class="pb-countdown" data-date="2030-01-01T00:00:00">
   <span class="pb-countdown-display">00:00:00:00</span>
@@ -23,3 +24,4 @@
   }
   document.querySelectorAll('.pb-countdown').forEach(update);
 })();</script>
+<?php ob_end_flush(); ?>

--- a/pagebuilder/widgets/heading.php
+++ b/pagebuilder/widgets/heading.php
@@ -1,3 +1,5 @@
 <?php
+ob_start();
 ?>
 <h2 class="pb-heading text-xl font-bold">Überschrift</h2>
+<?php ob_end_flush(); ?>

--- a/pagebuilder/widgets/image.php
+++ b/pagebuilder/widgets/image.php
@@ -1,3 +1,5 @@
 <?php
+ob_start();
 ?>
 <img src="https://via.placeholder.com/300x200" alt="Bild" class="pb-image" />
+<?php ob_end_flush(); ?>

--- a/pagebuilder/widgets/list.php
+++ b/pagebuilder/widgets/list.php
@@ -1,6 +1,8 @@
 <?php
+ob_start();
 ?>
 <ul class="pb-list list-disc pl-6">
   <li>Listelement 1</li>
   <li>Listelement 2</li>
 </ul>
+<?php ob_end_flush(); ?>

--- a/pagebuilder/widgets/product_grid.php
+++ b/pagebuilder/widgets/product_grid.php
@@ -1,3 +1,5 @@
 <?php
+ob_start();
 ?>
 <div class="pb-product-grid" data-category="" data-limit="6">Produkt-Grid wird geladen...</div>
+<?php ob_end_flush(); ?>

--- a/pagebuilder/widgets/section.php
+++ b/pagebuilder/widgets/section.php
@@ -1,3 +1,5 @@
 <?php
+ob_start();
 ?>
 <section class="pb-section p-4 bg-gray-100">Section Inhalt</section>
+<?php ob_end_flush(); ?>

--- a/pagebuilder/widgets/slider.php
+++ b/pagebuilder/widgets/slider.php
@@ -1,4 +1,5 @@
 <?php
+ob_start();
 $images = isset($images) && is_array($images)
     ? array_values(array_filter($images, static function ($src) {
         return is_string($src) && trim($src) !== '';
@@ -40,3 +41,4 @@ if (count($images) === 0) {
     show(0);
   });
 })();</script>
+<?php ob_end_flush(); ?>

--- a/pagebuilder/widgets/spacer.php
+++ b/pagebuilder/widgets/spacer.php
@@ -1,3 +1,5 @@
 <?php
+ob_start();
 ?>
 <div class="pb-spacer my-4"></div>
+<?php ob_end_flush(); ?>

--- a/pagebuilder/widgets/tabs.php
+++ b/pagebuilder/widgets/tabs.php
@@ -1,4 +1,5 @@
 <?php
+ob_start();
 ?>
 <div class="pb-tabs">
   <div class="pb-tab-headers">
@@ -33,3 +34,4 @@
     });
   });
 })();</script>
+<?php ob_end_flush(); ?>

--- a/pagebuilder/widgets/text.php
+++ b/pagebuilder/widgets/text.php
@@ -1,3 +1,5 @@
 <?php
+ob_start();
 ?>
 <div class="pb-text">Hier steht ein einfacher Text.</div>
+<?php ob_end_flush(); ?>

--- a/pagebuilder/widgets/video.php
+++ b/pagebuilder/widgets/video.php
@@ -1,5 +1,7 @@
 <?php
+ob_start();
 ?>
 <div class="pb-video">
   <iframe src="https://www.youtube.com/embed/dQw4w9WgXcQ" frameborder="0" allowfullscreen class="w-full h-48"></iframe>
 </div>
+<?php ob_end_flush(); ?>


### PR DESCRIPTION
## Summary
- wrap builder PHP files with `ob_start`/`ob_end_flush`
- do the same for each page builder widget

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c63b3171883218acb4c7afb21457d