### PR TITLE
Add flexible video widget with preview

### DIFF
--- a/assets/dynamic-widgets.js
+++ b/assets/dynamic-widgets.js
@@ -20,6 +20,53 @@
       el.textContent='Fehler beim Laden';
     }
   }
+  function initVideo(el){
+    const type=el.dataset.type||'youtube';
+    const src=el.dataset.src||'';
+    const preview=el.dataset.preview||'';
+    function create(){
+      const wrap=document.createElement('div');
+      wrap.className='pb-video-wrapper';
+      if(type==='youtube'){
+        const id=src.split('v=')[1]||src.split('/').pop();
+        const ifr=document.createElement('iframe');
+        ifr.src='https://www.youtube.com/embed/'+id;
+        ifr.setAttribute('frameborder','0');
+        ifr.allowFullscreen=true;
+        wrap.appendChild(ifr);
+      }else if(type==='vimeo'){
+        const id=src.split('/').pop();
+        const ifr=document.createElement('iframe');
+        ifr.src='https://player.vimeo.com/video/'+id;
+        ifr.setAttribute('frameborder','0');
+        ifr.allowFullscreen=true;
+        wrap.appendChild(ifr);
+      }else{
+        const vid=document.createElement('video');
+        vid.src=src;
+        vid.controls=true;
+        wrap.appendChild(vid);
+      }
+      el.innerHTML='';
+      el.appendChild(wrap);
+      el.classList.remove('pb-video-clickable');
+    }
+    if(preview){
+      const img=document.createElement('img');
+      img.src=preview;
+      img.className='pb-video-preview';
+      const btn=document.createElement('div');
+      btn.className='pb-video-play';
+      btn.textContent='▶';
+      el.innerHTML='';
+      el.appendChild(img);
+      el.appendChild(btn);
+      el.classList.add('pb-video-clickable');
+      el.addEventListener('click',()=>create(),{once:true});
+    }else{
+      create();
+    }
+  }
   function initAnimations(){
     if(window._widgetAnimObserver){window._widgetAnimObserver.disconnect();}
     const observer=new IntersectionObserver(entries=>{
@@ -46,8 +93,12 @@
   document.addEventListener('DOMContentLoaded',function(){
     document.querySelectorAll('.pb-product-grid').forEach(loadProductGrid);
     document.querySelectorAll('.pb-category-list').forEach(loadCategoryList);
+    document.querySelectorAll('.pb-video').forEach(initVideo);
     initAnimations();
   });
 
   window.initWidgetAnimations=initAnimations;
+  window.initVideos=function(){
+    document.querySelectorAll('.pb-video').forEach(initVideo);
+  };
 })();

--- a/pagebuilder/assets/builder.js
+++ b/pagebuilder/assets/builder.js
@@ -91,6 +91,7 @@ function initBuilder() {
     bpButtons.forEach(btn => btn.classList.toggle('active', btn.dataset.bp === bp));
     updateAllConfigs();
     if (window.initWidgetAnimations) window.initWidgetAnimations();
+    if (window.initVideos) window.initVideos();
   }
 
   function updateAllConfigs() {
@@ -224,9 +225,18 @@ function initBuilder() {
     if (el.dataset.widget === 'category_list') {
       if (cfg.limit !== undefined) el.dataset.limit = cfg.limit;
     }
+    if (el.dataset.widget === 'video') {
+      if (cfg.videoType !== undefined) el.dataset.type = cfg.videoType;
+      if (cfg.videoSrc !== undefined) el.dataset.src = cfg.videoSrc;
+      if (cfg.videoPreview !== undefined) {
+        if (cfg.videoPreview) el.dataset.preview = cfg.videoPreview;
+        else delete el.dataset.preview;
+      }
+    }
     if (cfg.animation) el.dataset.animation = cfg.animation; else delete el.dataset.animation;
     if (cfg.animTrigger) el.dataset.animTrigger = cfg.animTrigger; else delete el.dataset.animTrigger;
     if (window.initWidgetAnimations) window.initWidgetAnimations();
+    if (window.initVideos) window.initVideos();
   }
 
   let activeElement = null;
@@ -252,6 +262,7 @@ function initBuilder() {
     makeEditable(clone);
     save();
     if (window.initWidgetAnimations) window.initWidgetAnimations();
+    if (window.initVideos) window.initVideos();
   }
 
   async function pasteFromClipboard() {
@@ -282,6 +293,7 @@ function initBuilder() {
     });
     save();
     if (window.initWidgetAnimations) window.initWidgetAnimations();
+    if (window.initVideos) window.initVideos();
   }
 
   async function insertSelectedTemplate() {
@@ -367,6 +379,16 @@ function initBuilder() {
       widgetFields += `<label>Anzahl <input type="number" name="limit" value="${cfg.limit || 6}"></label>`;
     } else if (el.dataset.widget === 'category_list') {
       widgetFields += `<label>Anzahl <input type="number" name="limit" value="${cfg.limit || 10}"></label>`;
+    } else if (el.dataset.widget === 'video') {
+      widgetFields += `<label>Typ
+        <select name="videoType">
+          <option value="youtube" ${!cfg.videoType || cfg.videoType==='youtube' ? 'selected' : ''}>YouTube</option>
+          <option value="vimeo" ${cfg.videoType==='vimeo' ? 'selected' : ''}>Vimeo</option>
+          <option value="mp4" ${cfg.videoType==='mp4' ? 'selected' : ''}>MP4</option>
+        </select>
+      </label>`;
+      widgetFields += `<label>Quelle/URL <input type="text" name="videoSrc" value="${cfg.videoSrc || ''}"></label>`;
+      widgetFields += `<label>Vorschaubild <input type="text" name="videoPreview" value="${cfg.videoPreview || ''}"></label>`;
     }
 
     configPanel.innerHTML = `<div class="pb-config-bp flex justify-between items-center mb-2"><span>${currentBreakpoint.toUpperCase()}</span><button type="button" class="pb-close">✕</button></div>
@@ -419,6 +441,10 @@ function initBuilder() {
         data.limit = configPanel.querySelector('input[name="limit"]').value.trim();
       } else if (el.dataset.widget === 'category_list') {
         data.limit = configPanel.querySelector('input[name="limit"]').value.trim();
+      } else if (el.dataset.widget === 'video') {
+        data.videoType = configPanel.querySelector('select[name="videoType"]').value;
+        data.videoSrc = configPanel.querySelector('input[name="videoSrc"]').value.trim();
+        data.videoPreview = configPanel.querySelector('input[name="videoPreview"]').value.trim();
       }
       el.dataset.config = JSON.stringify(data);
       applyConfig(el, data);
@@ -441,6 +467,9 @@ function initBuilder() {
       el.classList.remove('pb-hide-mobile','pb-hide-desktop');
       delete el.dataset.category;
       delete el.dataset.limit;
+      delete el.dataset.type;
+      delete el.dataset.src;
+      delete el.dataset.preview;
       delete el.dataset.animation;
       delete el.dataset.animTrigger;
       applyConfig(el, {});
@@ -465,6 +494,7 @@ function initBuilder() {
     makeEditable(wrapper);
     save();
     if (window.initWidgetAnimations) window.initWidgetAnimations();
+    if (window.initVideos) window.initVideos();
   }
 
   widgetBar.querySelectorAll('button[data-widget]').forEach(btn => {

--- a/pagebuilder/widgets/video.php
+++ b/pagebuilder/widgets/video.php
@@ -1,7 +1,71 @@
 <?php
 ob_start();
+$src = isset($src) ? trim($src) : 'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
+$preview = isset($preview) ? trim($preview) : '';
+if (preg_match('~(youtube\.com/watch\?v=|youtu\.be/)~', $src)) {
+    $type = 'youtube';
+} elseif (strpos($src, 'vimeo.com') !== false) {
+    $type = 'vimeo';
+} else {
+    $type = 'mp4';
+}
 ?>
-<div class="pb-video">
-  <iframe src="https://www.youtube.com/embed/dQw4w9WgXcQ" frameborder="0" allowfullscreen class="w-full h-48"></iframe>
-</div>
+<div class="pb-video" data-type="<?= htmlspecialchars($type, ENT_QUOTES) ?>" data-src="<?= htmlspecialchars($src, ENT_QUOTES) ?>"<?php if ($preview): ?> data-preview="<?= htmlspecialchars($preview, ENT_QUOTES) ?>"<?php endif; ?>></div>
+<style>
+.pb-video{position:relative;max-width:100%;cursor:pointer;}
+.pb-video-wrapper{position:relative;width:100%;padding-bottom:56.25%;height:0;overflow:hidden;}
+.pb-video-wrapper iframe,.pb-video-wrapper video{position:absolute;top:0;left:0;width:100%;height:100%;}
+.pb-video-preview{display:block;width:100%;height:auto;}
+.pb-video-play{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);background:rgba(0,0,0,0.6);color:#fff;border:none;border-radius:50%;width:48px;height:48px;font-size:1.5rem;line-height:48px;text-align:center;}
+</style>
+<script>(function(){
+  function init(el){
+    var type=el.dataset.type||'youtube';
+    var src=el.dataset.src||'';
+    var preview=el.dataset.preview||'';
+    function createPlayer(){
+      var wrapper=document.createElement('div');
+      wrapper.className='pb-video-wrapper';
+      if(type==='youtube'){
+        var id=src.split('v=')[1]||src.split('/').pop();
+        var iframe=document.createElement('iframe');
+        iframe.src='https://www.youtube.com/embed/'+id;
+        iframe.setAttribute('frameborder','0');
+        iframe.allowFullscreen=true;
+        wrapper.appendChild(iframe);
+      }else if(type==='vimeo'){
+        var id=src.split('/').pop();
+        var iframe=document.createElement('iframe');
+        iframe.src='https://player.vimeo.com/video/'+id;
+        iframe.setAttribute('frameborder','0');
+        iframe.allowFullscreen=true;
+        wrapper.appendChild(iframe);
+      }else{
+        var video=document.createElement('video');
+        video.src=src;
+        video.controls=true;
+        wrapper.appendChild(video);
+      }
+      el.innerHTML='';
+      el.appendChild(wrapper);
+      el.classList.remove('pb-video-clickable');
+    }
+    if(preview){
+      var img=document.createElement('img');
+      img.src=preview;
+      img.className='pb-video-preview';
+      var btn=document.createElement('div');
+      btn.className='pb-video-play';
+      btn.textContent='▶';
+      el.innerHTML='';
+      el.appendChild(img);
+      el.appendChild(btn);
+      el.classList.add('pb-video-clickable');
+      el.addEventListener('click',function(){createPlayer();},{once:true});
+    }else{
+      createPlayer();
+    }
+  }
+  document.querySelectorAll('.pb-video').forEach(init);
+})();</script>
 <?php ob_end_flush(); ?>


### PR DESCRIPTION
## Summary
- add dynamic video widget supporting YouTube/Vimeo/MP4
- initialise and preview videos via global JS
- integrate video settings into builder config panel

## Testing
- `php -l pagebuilder/widgets/video.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ca066e9b483219aecd52d09362b72