### PR TITLE
Redesign admin navigation

### DIFF
--- a/admin/bestellungen.php
+++ b/admin/bestellungen.php
@@ -5,6 +5,7 @@ if (!isset($_SESSION['admin'])) {
     exit;
 }
 require '../inc/db.php';
+require '../inc/admin_header.php';
 
 $bestellungen = $pdo->query("SELECT * FROM bestellungen ORDER BY zeitstempel DESC")->fetchAll(PDO::FETCH_ASSOC);
 ?>
@@ -28,42 +29,7 @@ $bestellungen = $pdo->query("SELECT * FROM bestellungen ORDER BY zeitstempel DES
     <style>body { font-family: 'Inter', sans-serif; }</style>
 </head>
 <body class="bg-gray-50 text-gray-900">
-    <header class="bg-white border-b shadow-sm">
-        <div class="max-w-5xl mx-auto flex justify-between items-center py-6 px-4">
-            <span class="text-2xl font-extrabold tracking-tight">nezbi Admin</span>
-            <div class="flex items-center">
-                <button id="menuBtn" class="md:hidden mr-4 text-gray-600" aria-label="Menü öffnen">
-                    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-                    </svg>
-                </button>
-                <a href="logout.php" class="inline-block rounded-xl px-4 py-2 bg-blue-600 text-white font-medium hover:bg-blue-700 transition">Logout</a>
-            </div>
-        </div>
-        <nav id="navLinks" class="hidden flex-col space-y-2 px-4 pb-4 md:flex md:flex-row md:space-y-0 md:space-x-8 md:max-w-5xl md:mx-auto">
-            <a href="dashboard.php" class="hover:text-blue-600">Dashboard</a>
-            <a href="produkte.php" class="hover:text-blue-600">Produkte</a>
-            <a href="kategorien.php" class="hover:text-blue-600">Kategorien</a>
-            <a href="rabattcodes.php" class="hover:text-blue-600">Rabatte</a>
-            <a href="bestellungen.php" class="font-bold text-blue-600">Bestellungen</a>
-            <a href="insights.php" class="hover:text-blue-600">Insights</a>
-            <a href="pages.php" class="hover:text-blue-600">Seiten</a>
-        <a href="modular_builder.php" class="hover:text-blue-600">Builder</a>
-        <a href="popup_builder.php" class="hover:text-blue-600">Popups</a>
-            <a href="templates.php" class="hover:text-blue-600">Templates</a>
-        </nav>
-    </header>
-    <script>
-    document.addEventListener('DOMContentLoaded',function(){
-        var b=document.getElementById('menuBtn');
-        var n=document.getElementById('navLinks');
-        if(b&&n){
-            b.addEventListener('click',function(){
-                n.classList.toggle('hidden');
-            });
-        }
-    });
-    </script>
+    <?php admin_header('bestellungen'); ?>
     <main class="max-w-5xl mx-auto px-4 py-10">
         <h1 class="text-2xl font-bold mb-8">Bestellungen</h1>
         <div class="overflow-x-auto">

--- a/admin/customize.php
+++ b/admin/customize.php
@@ -2,6 +2,7 @@
 session_start();
 if(!isset($_SESSION['admin'])){header('Location: ../login.php');exit;}
 require '../inc/db.php';
+require '../inc/admin_header.php';
 $pages = $pdo->query("SELECT id, title FROM pages ORDER BY title")->fetchAll(PDO::FETCH_ASSOC);
 $id = isset($_GET['id']) ? intval($_GET['id']) : ($pages[0]['id'] ?? 0);
 $page = ['title'=>'','slug'=>'','content'=>'','meta_title'=>'','meta_description'=>'','canonical_url'=>'','jsonld'=>''];
@@ -43,35 +44,7 @@ if($_SERVER['REQUEST_METHOD']==='POST'){
 <style>body{font-family:'Inter',sans-serif;}</style>
 </head>
 <body class="bg-gray-50 text-gray-900">
-<header class="bg-white border-b shadow-sm">
-    <div class="max-w-5xl mx-auto flex justify-between items-center py-6 px-4">
-        <span class="text-2xl font-extrabold tracking-tight">nezbi Admin</span>
-        <div class="flex items-center">
-            <button id="menuBtn" class="md:hidden mr-4 text-gray-600" aria-label="Menü öffnen">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-                </svg>
-            </button>
-            <a href="logout.php" class="inline-block rounded-xl px-4 py-2 bg-blue-600 text-white font-medium hover:bg-blue-700 transition">Logout</a>
-        </div>
-    </div>
-    <nav id="navLinks" class="hidden flex-col space-y-2 px-4 pb-4 md:flex md:flex-row md:space-y-0 md:space-x-8 md:max-w-5xl md:mx-auto">
-        <a href="dashboard.php" class="hover:text-blue-600">Dashboard</a>
-        <a href="produkte.php" class="hover:text-blue-600">Produkte</a>
-        <a href="kategorien.php" class="hover:text-blue-600">Kategorien</a>
-        <a href="rabattcodes.php" class="hover:text-blue-600">Rabatte</a>
-        <a href="bestellungen.php" class="hover:text-blue-600">Bestellungen</a>
-        <a href="insights.php" class="hover:text-blue-600">Insights</a>
-        <a href="pages.php" class="hover:text-blue-600">Seiten</a>
-        <a href="modular_builder.php" class="hover:text-blue-600">Builder</a>
-        <a href="popup_builder.php" class="hover:text-blue-600">Popups</a>
-        <a href="customize.php" class="font-bold text-blue-600">Website bearbeiten</a>
-        <a href="templates.php" class="hover:text-blue-600">Templates</a>
-    </nav>
-</header>
-<script>
- document.addEventListener('DOMContentLoaded',function(){var b=document.getElementById('menuBtn');var n=document.getElementById('navLinks');if(b&&n){b.addEventListener('click',function(){n.classList.toggle('hidden');});}});
-</script>
+<?php admin_header('customize'); ?>
 <main class="max-w-5xl mx-auto px-4 py-10">
 <h1 class="text-2xl font-bold mb-8">Seite bearbeiten</h1>
 <div class="mb-4">

--- a/admin/dashboard.php
+++ b/admin/dashboard.php
@@ -5,6 +5,7 @@ if (!isset($_SESSION['admin'])) {
     exit;
 }
 require '../inc/db.php';
+require '../inc/admin_header.php';
 require '../inc/settings.php';
 $siteSettings = load_settings();
 ?>
@@ -33,44 +34,7 @@ $siteSettings = load_settings();
     </style>
 </head>
 <body class="bg-gray-50 text-gray-900">
-    <header class="bg-white border-b shadow-sm">
-        <div class="max-w-5xl mx-auto flex justify-between items-center py-6 px-4">
-            <span class="text-2xl font-extrabold tracking-tight">nezbi Admin</span>
-            <div class="flex items-center">
-                <button id="menuBtn" class="md:hidden mr-4 text-gray-600" aria-label="Menü öffnen">
-                    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-                    </svg>
-                </button>
-                <a href="logout.php" class="inline-block rounded-xl px-4 py-2 accent-bg text-white font-medium hover:opacity-90 transition">Logout</a>
-            </div>
-        </div>
-        <nav id="navLinks" class="hidden flex-col space-y-2 px-4 pb-4 md:flex md:flex-row md:space-y-0 md:space-x-8 md:max-w-5xl md:mx-auto">
-            <a href="dashboard.php" class="font-bold text-blue-600">Dashboard</a>
-            <a href="produkte.php" class="hover:text-blue-600">Produkte</a>
-            <a href="kategorien.php" class="hover:text-blue-600">Kategorien</a>
-            <a href="rabattcodes.php" class="hover:text-blue-600">Rabatte</a>
-            <a href="bestellungen.php" class="hover:text-blue-600">Bestellungen</a>
-            <a href="insights.php" class="hover:text-blue-600">Insights</a>
-            <a href="pages.php" class="hover:text-blue-600">Seiten</a>
-        <a href="modular_builder.php" class="hover:text-blue-600">Builder</a>
-        <a href="popup_builder.php" class="hover:text-blue-600">Popups</a>
-        <a href="design.php" class="hover:text-blue-600">Design</a>
-        <a href="customize.php" class="hover:text-blue-600">Website bearbeiten</a>
-            <a href="templates.php" class="hover:text-blue-600">Templates</a>
-        </nav>
-    </header>
-    <script>
-    document.addEventListener('DOMContentLoaded',function(){
-        var b=document.getElementById('menuBtn');
-        var n=document.getElementById('navLinks');
-        if(b&&n){
-            b.addEventListener('click',function(){
-                n.classList.toggle('hidden');
-            });
-        }
-    });
-    </script>
+    <?php admin_header('dashboard'); ?>
     <main class="max-w-5xl mx-auto px-4 py-10">
         <h1 class="text-2xl font-bold mb-4">nezbi Admin Dashboard</h1>
         <a href="customize.php" class="inline-block mb-8 px-4 py-2 accent-bg text-white rounded-xl">Website bearbeiten</a>

--- a/admin/edit_page.php
+++ b/admin/edit_page.php
@@ -2,6 +2,7 @@
 session_start();
 if(!isset($_SESSION['admin'])){header('Location: ../login.php');exit;}
 require '../inc/db.php';
+require '../inc/admin_header.php';
 $action = $_POST['action'] ?? null;
 if($action==='delete' && isset($_POST['id'])){
     $stmt=$pdo->prepare('DELETE FROM pages WHERE id=?');
@@ -49,35 +50,7 @@ if($_SERVER['REQUEST_METHOD']==='POST' && !$action){
 <style>body{font-family:'Inter',sans-serif;}</style>
 </head>
 <body class="bg-gray-50 text-gray-900">
-<header class="bg-white border-b shadow-sm">
-    <div class="max-w-5xl mx-auto flex justify-between items-center py-6 px-4">
-        <span class="text-2xl font-extrabold tracking-tight">nezbi Admin</span>
-        <div class="flex items-center">
-            <button id="menuBtn" class="md:hidden mr-4 text-gray-600" aria-label="Menü öffnen">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-                </svg>
-            </button>
-            <a href="logout.php" class="inline-block rounded-xl px-4 py-2 bg-blue-600 text-white font-medium hover:bg-blue-700 transition">Logout</a>
-        </div>
-    </div>
-    <nav id="navLinks" class="hidden flex-col space-y-2 px-4 pb-4 md:flex md:flex-row md:space-y-0 md:space-x-8 md:max-w-5xl md:mx-auto">
-        <a href="dashboard.php" class="hover:text-blue-600">Dashboard</a>
-        <a href="produkte.php" class="hover:text-blue-600">Produkte</a>
-        <a href="kategorien.php" class="hover:text-blue-600">Kategorien</a>
-        <a href="rabattcodes.php" class="hover:text-blue-600">Rabatte</a>
-        <a href="bestellungen.php" class="hover:text-blue-600">Bestellungen</a>
-        <a href="insights.php" class="hover:text-blue-600">Insights</a>
-        <a href="pages.php" class="text-blue-600 font-bold">Seiten</a>
-        <a href="modular_builder.php" class="hover:text-blue-600">Builder</a>
-        <a href="popup_builder.php" class="hover:text-blue-600">Popups</a>
-        <a href="customize.php" class="hover:text-blue-600">Website bearbeiten</a>
-        <a href="templates.php" class="hover:text-blue-600">Templates</a>
-    </nav>
-</header>
-<script>
-document.addEventListener('DOMContentLoaded',function(){var b=document.getElementById('menuBtn');var n=document.getElementById('navLinks');if(b&&n){b.addEventListener('click',function(){n.classList.toggle('hidden');});}});
-</script>
+<?php admin_header('seiten'); ?>
 <main class="max-w-5xl mx-auto px-4 py-10">
 <h1 class="text-2xl font-bold mb-8">Seite bearbeiten</h1>
 <form method="post" id="pageForm" class="bg-white shadow rounded-xl p-6 space-y-4">

--- a/admin/insights.php
+++ b/admin/insights.php
@@ -5,6 +5,7 @@ if (!isset($_SESSION['admin'])) {
     exit;
 }
 require '../inc/db.php';
+require '../inc/admin_header.php';
 
 $gesamt = $pdo->query("SELECT COUNT(*) AS anzahl, SUM(summe) AS umsatz FROM bestellungen")->fetch(PDO::FETCH_ASSOC);
 $tage = $pdo->query("SELECT DATE(zeitstempel) AS tag, COUNT(*) AS anzahl, SUM(summe) AS umsatz FROM bestellungen GROUP BY DATE(zeitstempel) ORDER BY tag DESC LIMIT 7")->fetchAll(PDO::FETCH_ASSOC);
@@ -29,42 +30,7 @@ $tage = $pdo->query("SELECT DATE(zeitstempel) AS tag, COUNT(*) AS anzahl, SUM(su
     <style>body { font-family: 'Inter', sans-serif; }</style>
 </head>
 <body class="bg-gray-50 text-gray-900">
-    <header class="bg-white border-b shadow-sm">
-        <div class="max-w-5xl mx-auto flex justify-between items-center py-6 px-4">
-            <span class="text-2xl font-extrabold tracking-tight">nezbi Admin</span>
-            <div class="flex items-center">
-                <button id="menuBtn" class="md:hidden mr-4 text-gray-600" aria-label="Menü öffnen">
-                    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-                    </svg>
-                </button>
-                <a href="logout.php" class="inline-block rounded-xl px-4 py-2 bg-blue-600 text-white font-medium hover:bg-blue-700 transition">Logout</a>
-            </div>
-        </div>
-        <nav id="navLinks" class="hidden flex-col space-y-2 px-4 pb-4 md:flex md:flex-row md:space-y-0 md:space-x-8 md:max-w-5xl md:mx-auto">
-            <a href="dashboard.php" class="hover:text-blue-600">Dashboard</a>
-            <a href="produkte.php" class="hover:text-blue-600">Produkte</a>
-            <a href="kategorien.php" class="hover:text-blue-600">Kategorien</a>
-            <a href="rabattcodes.php" class="hover:text-blue-600">Rabatte</a>
-            <a href="bestellungen.php" class="hover:text-blue-600">Bestellungen</a>
-            <a href="insights.php" class="font-bold text-blue-600">Insights</a>
-            <a href="pages.php" class="hover:text-blue-600">Seiten</a>
-        <a href="modular_builder.php" class="hover:text-blue-600">Builder</a>
-        <a href="popup_builder.php" class="hover:text-blue-600">Popups</a>
-            <a href="templates.php" class="hover:text-blue-600">Templates</a>
-        </nav>
-    </header>
-    <script>
-    document.addEventListener('DOMContentLoaded',function(){
-        var b=document.getElementById('menuBtn');
-        var n=document.getElementById('navLinks');
-        if(b&&n){
-            b.addEventListener('click',function(){
-                n.classList.toggle('hidden');
-            });
-        }
-    });
-    </script>
+    <?php admin_header('insights'); ?>
     <main class="max-w-5xl mx-auto px-4 py-10">
         <h1 class="text-2xl font-bold mb-8">Statistiken</h1>
         <div class="grid grid-cols-1 md:grid-cols-3 gap-8 mb-12">

--- a/admin/kategorien.php
+++ b/admin/kategorien.php
@@ -5,6 +5,7 @@ if (!isset($_SESSION['admin'])) {
     exit;
 }
 require '../inc/db.php';
+require '../inc/admin_header.php';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $action = $_POST['action'] ?? 'add';
@@ -43,42 +44,7 @@ $kategorien = $pdo->query("SELECT * FROM kategorien ORDER BY name")->fetchAll(PD
     <style>body { font-family: 'Inter', sans-serif; }</style>
 </head>
 <body class="bg-gray-50 text-gray-900">
-    <header class="bg-white border-b shadow-sm">
-        <div class="max-w-5xl mx-auto flex justify-between items-center py-6 px-4">
-            <span class="text-2xl font-extrabold tracking-tight">nezbi Admin</span>
-            <div class="flex items-center">
-                <button id="menuBtn" class="md:hidden mr-4 text-gray-600" aria-label="Menü öffnen">
-                    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-                    </svg>
-                </button>
-                <a href="logout.php" class="inline-block rounded-xl px-4 py-2 bg-blue-600 text-white font-medium hover:bg-blue-700 transition">Logout</a>
-            </div>
-        </div>
-        <nav id="navLinks" class="hidden flex-col space-y-2 px-4 pb-4 md:flex md:flex-row md:space-y-0 md:space-x-8 md:max-w-5xl md:mx-auto">
-            <a href="dashboard.php" class="hover:text-blue-600">Dashboard</a>
-            <a href="produkte.php" class="hover:text-blue-600">Produkte</a>
-            <a href="kategorien.php" class="font-bold text-blue-600">Kategorien</a>
-            <a href="rabattcodes.php" class="hover:text-blue-600">Rabatte</a>
-            <a href="bestellungen.php" class="hover:text-blue-600">Bestellungen</a>
-            <a href="insights.php" class="hover:text-blue-600">Insights</a>
-            <a href="pages.php" class="hover:text-blue-600">Seiten</a>
-        <a href="modular_builder.php" class="hover:text-blue-600">Builder</a>
-        <a href="popup_builder.php" class="hover:text-blue-600">Popups</a>
-            <a href="templates.php" class="hover:text-blue-600">Templates</a>
-        </nav>
-    </header>
-    <script>
-    document.addEventListener('DOMContentLoaded',function(){
-        var b=document.getElementById('menuBtn');
-        var n=document.getElementById('navLinks');
-        if(b&&n){
-            b.addEventListener('click',function(){
-                n.classList.toggle('hidden');
-            });
-        }
-    });
-    </script>
+    <?php admin_header('kategorien'); ?>
     <main class="max-w-5xl mx-auto px-4 py-10">
         <h1 class="text-2xl font-bold mb-8">Kategorien verwalten</h1>
         <form method="post" class="bg-white shadow rounded-xl p-6 mb-10">

--- a/admin/pages.php
+++ b/admin/pages.php
@@ -2,6 +2,7 @@
 session_start();
 if(!isset($_SESSION['admin'])){header('Location: ../login.php');exit;}
 require '../inc/db.php';
+require '../inc/admin_header.php';
 $pages = $pdo->query("SELECT * FROM pages ORDER BY id")->fetchAll(PDO::FETCH_ASSOC);
 ?>
 <!DOCTYPE html>
@@ -15,39 +16,7 @@ $pages = $pdo->query("SELECT * FROM pages ORDER BY id")->fetchAll(PDO::FETCH_ASS
 <style>body{font-family:'Inter',sans-serif;}</style>
 </head>
 <body class="bg-gray-50 text-gray-900">
-<header class="bg-white border-b shadow-sm">
-    <div class="max-w-5xl mx-auto flex justify-between items-center py-6 px-4">
-        <span class="text-2xl font-extrabold tracking-tight">nezbi Admin</span>
-        <div class="flex items-center">
-            <button id="menuBtn" class="md:hidden mr-4 text-gray-600" aria-label="Menü öffnen">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-                </svg>
-            </button>
-            <a href="logout.php" class="inline-block rounded-xl px-4 py-2 bg-blue-600 text-white font-medium hover:bg-blue-700 transition">Logout</a>
-        </div>
-    </div>
-    <nav id="navLinks" class="hidden flex-col space-y-2 px-4 pb-4 md:flex md:flex-row md:space-y-0 md:space-x-8 md:max-w-5xl md:mx-auto">
-        <a href="dashboard.php" class="hover:text-blue-600">Dashboard</a>
-        <a href="produkte.php" class="hover:text-blue-600">Produkte</a>
-        <a href="kategorien.php" class="hover:text-blue-600">Kategorien</a>
-        <a href="rabattcodes.php" class="hover:text-blue-600">Rabatte</a>
-        <a href="bestellungen.php" class="hover:text-blue-600">Bestellungen</a>
-        <a href="insights.php" class="hover:text-blue-600">Insights</a>
-        <a href="pages.php" class="font-bold text-blue-600">Seiten</a>
-        <a href="modular_builder.php" class="hover:text-blue-600">Builder</a>
-        <a href="popup_builder.php" class="hover:text-blue-600">Popups</a>
-        <a href="customize.php" class="hover:text-blue-600">Website bearbeiten</a>
-        <a href="templates.php" class="hover:text-blue-600">Templates</a>
-    </nav>
-</header>
-<script>
-document.addEventListener('DOMContentLoaded',function(){
-    var b=document.getElementById('menuBtn');
-    var n=document.getElementById('navLinks');
-    if(b&&n){b.addEventListener('click',function(){n.classList.toggle('hidden');});}
-});
-</script>
+<?php admin_header('seiten'); ?>
 <main class="max-w-5xl mx-auto px-4 py-10">
     <h1 class="text-2xl font-bold mb-8">Seiten</h1>
     <a href="page_builder.php" class="mb-4 inline-block px-4 py-2 bg-blue-600 text-white rounded">Neue Seite</a>

--- a/admin/produkte.php
+++ b/admin/produkte.php
@@ -5,7 +5,7 @@ if (!isset($_SESSION['admin'])) {
     exit;
 }
 require '../inc/db.php';
-
+require '../inc/admin_header.php';
 // Automatische Aktualisierung der Datenbank um neue Spalten
 try { $pdo->query("SELECT rabatt FROM produkte LIMIT 1"); }
 catch (PDOException $e) { if (strpos($e->getMessage(),'rabatt')!==false) { $pdo->exec("ALTER TABLE produkte ADD COLUMN rabatt DECIMAL(10,2) DEFAULT NULL"); } }
@@ -83,42 +83,7 @@ $kategorien = $pdo->query("SELECT * FROM kategorien ORDER BY name")->fetchAll(PD
     <style>body { font-family: 'Inter', sans-serif; }</style>
 </head>
 <body class="bg-gray-50 text-gray-900">
-    <header class="bg-white border-b shadow-sm">
-        <div class="max-w-5xl mx-auto flex justify-between items-center py-6 px-4">
-            <span class="text-2xl font-extrabold tracking-tight">nezbi Admin</span>
-            <div class="flex items-center">
-                <button id="menuBtn" class="md:hidden mr-4 text-gray-600" aria-label="Menü öffnen">
-                    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-                    </svg>
-                </button>
-                <a href="logout.php" class="inline-block rounded-xl px-4 py-2 bg-blue-600 text-white font-medium hover:bg-blue-700 transition">Logout</a>
-            </div>
-        </div>
-        <nav id="navLinks" class="hidden flex-col space-y-2 px-4 pb-4 md:flex md:flex-row md:space-y-0 md:space-x-8 md:max-w-5xl md:mx-auto">
-            <a href="dashboard.php" class="hover:text-blue-600">Dashboard</a>
-            <a href="produkte.php" class="font-bold text-blue-600">Produkte</a>
-            <a href="kategorien.php" class="hover:text-blue-600">Kategorien</a>
-            <a href="rabattcodes.php" class="hover:text-blue-600">Rabatte</a>
-            <a href="bestellungen.php" class="hover:text-blue-600">Bestellungen</a>
-            <a href="insights.php" class="hover:text-blue-600">Insights</a>
-            <a href="pages.php" class="hover:text-blue-600">Seiten</a>
-        <a href="modular_builder.php" class="hover:text-blue-600">Builder</a>
-        <a href="popup_builder.php" class="hover:text-blue-600">Popups</a>
-            <a href="templates.php" class="hover:text-blue-600">Templates</a>
-        </nav>
-    </header>
-    <script>
-    document.addEventListener('DOMContentLoaded',function(){
-        var b=document.getElementById('menuBtn');
-        var n=document.getElementById('navLinks');
-        if(b&&n){
-            b.addEventListener('click',function(){
-                n.classList.toggle('hidden');
-            });
-        }
-    });
-    </script>
+    <?php admin_header("produkte"); ?>
     <main class="max-w-5xl mx-auto px-4 py-10">
         <h1 class="text-2xl font-bold mb-8">Produkte</h1>
         <form method="post" class="bg-white shadow rounded-xl p-6 mb-10">

--- a/admin/rabattcodes.php
+++ b/admin/rabattcodes.php
@@ -5,6 +5,7 @@ if (!isset($_SESSION['admin'])) {
     exit;
 }
 require '../inc/db.php';
+require '../inc/admin_header.php';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $stmt = $pdo->prepare("INSERT INTO rabattcodes (code, typ, wert, aktiv) VALUES (?,?,?,?)");
@@ -38,42 +39,7 @@ $codes = $pdo->query("SELECT * FROM rabattcodes ORDER BY id DESC")->fetchAll(PDO
     <style>body { font-family: 'Inter', sans-serif; }</style>
 </head>
 <body class="bg-gray-50 text-gray-900">
-    <header class="bg-white border-b shadow-sm">
-        <div class="max-w-5xl mx-auto flex justify-between items-center py-6 px-4">
-            <span class="text-2xl font-extrabold tracking-tight">nezbi Admin</span>
-            <div class="flex items-center">
-                <button id="menuBtn" class="md:hidden mr-4 text-gray-600" aria-label="Menü öffnen">
-                    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-                    </svg>
-                </button>
-                <a href="logout.php" class="inline-block rounded-xl px-4 py-2 bg-blue-600 text-white font-medium hover:bg-blue-700 transition">Logout</a>
-            </div>
-        </div>
-        <nav id="navLinks" class="hidden flex-col space-y-2 px-4 pb-4 md:flex md:flex-row md:space-y-0 md:space-x-8 md:max-w-5xl md:mx-auto">
-            <a href="dashboard.php" class="hover:text-blue-600">Dashboard</a>
-            <a href="produkte.php" class="hover:text-blue-600">Produkte</a>
-            <a href="kategorien.php" class="hover:text-blue-600">Kategorien</a>
-            <a href="rabattcodes.php" class="font-bold text-blue-600">Rabatte</a>
-            <a href="bestellungen.php" class="hover:text-blue-600">Bestellungen</a>
-            <a href="insights.php" class="hover:text-blue-600">Insights</a>
-            <a href="pages.php" class="hover:text-blue-600">Seiten</a>
-        <a href="modular_builder.php" class="hover:text-blue-600">Builder</a>
-        <a href="popup_builder.php" class="hover:text-blue-600">Popups</a>
-            <a href="templates.php" class="hover:text-blue-600">Templates</a>
-        </nav>
-    </header>
-    <script>
-    document.addEventListener('DOMContentLoaded',function(){
-        var b=document.getElementById('menuBtn');
-        var n=document.getElementById('navLinks');
-        if(b&&n){
-            b.addEventListener('click',function(){
-                n.classList.toggle('hidden');
-            });
-        }
-    });
-    </script>
+    <?php admin_header('rabatte'); ?>
     <main class="max-w-5xl mx-auto px-4 py-10">
         <h1 class="text-2xl font-bold mb-8">Rabattcodes</h1>
         <form method="post" class="bg-white shadow rounded-xl p-6 mb-10">

--- a/admin/templates.php
+++ b/admin/templates.php
@@ -25,31 +25,7 @@ $templates=[
 <style>body{font-family:'Inter',sans-serif;}</style>
 </head>
 <body class="bg-gray-50 text-gray-900">
-<header class="bg-white border-b shadow-sm">
-    <div class="max-w-5xl mx-auto flex justify-between items-center py-6 px-4">
-        <span class="text-2xl font-extrabold tracking-tight">nezbi Admin</span>
-        <div class="flex items-center">
-            <button id="menuBtn" class="md:hidden mr-4 text-gray-600" aria-label="Menü öffnen">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/></svg>
-            </button>
-            <a href="logout.php" class="inline-block rounded-xl px-4 py-2 bg-blue-600 text-white font-medium hover:bg-blue-700 transition">Logout</a>
-        </div>
-    </div>
-    <nav id="navLinks" class="hidden flex-col space-y-2 px-4 pb-4 md:flex md:flex-row md:space-y-0 md:space-x-8 md:max-w-5xl md:mx-auto">
-        <a href="dashboard.php" class="hover:text-blue-600">Dashboard</a>
-        <a href="produkte.php" class="hover:text-blue-600">Produkte</a>
-        <a href="kategorien.php" class="hover:text-blue-600">Kategorien</a>
-        <a href="rabattcodes.php" class="hover:text-blue-600">Rabatte</a>
-        <a href="bestellungen.php" class="hover:text-blue-600">Bestellungen</a>
-        <a href="insights.php" class="hover:text-blue-600">Insights</a>
-        <a href="pages.php" class="hover:text-blue-600">Seiten</a>
-        <a href="modular_builder.php" class="hover:text-blue-600">Builder</a>
-        <a href="popup_builder.php" class="hover:text-blue-600">Popups</a>
-        <a href="customize.php" class="hover:text-blue-600">Website bearbeiten</a>
-        <a href="templates.php" class="font-bold text-blue-600">Templates</a>
-    </nav>
-</header>
-<script>document.addEventListener('DOMContentLoaded',function(){var b=document.getElementById('menuBtn');var n=document.getElementById('navLinks');if(b&&n){b.addEventListener('click',function(){n.classList.toggle('hidden');});}});</script>
+<?php admin_header('templates'); ?>
 <main class="max-w-5xl mx-auto px-4 py-10 space-y-6">
     <h1 class="text-2xl font-bold mb-8">CSS Templates</h1>
     <p class="mb-4">Ziehe ein Template auf eine Seite im Editor, um es einzufügen.</p>

--- a/inc/admin_header.php
+++ b/inc/admin_header.php
@@ -1,0 +1,59 @@
+<?php
+function admin_header(string $active = '') {
+    require_once __DIR__ . '/settings.php';
+    $siteSettings = load_settings();
+    ?>
+<header class="bg-white border-b shadow-sm">
+    <div class="max-w-5xl mx-auto flex justify-between items-center py-6 px-4">
+        <span class="text-2xl font-extrabold tracking-tight">nezbi Admin</span>
+        <div class="flex items-center">
+            <button id="menuBtn" class="md:hidden mr-4 text-gray-600" aria-label="Menü öffnen">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+                </svg>
+            </button>
+            <a href="logout.php" class="inline-block rounded-xl px-4 py-2 accent-bg text-white font-medium hover:opacity-90 transition">Logout</a>
+        </div>
+    </div>
+    <nav id="navLinks" class="hidden flex-col space-y-2 px-4 pb-4 md:flex md:flex-row md:space-y-0 md:space-x-8 md:max-w-5xl md:mx-auto">
+        <a href="dashboard.php" class="<?php echo $active==='dashboard'?'font-bold text-blue-600':'hover:text-blue-600'; ?>">Dashboard</a>
+        <details class="group md:relative">
+            <summary class="cursor-pointer list-none flex items-center <?php echo in_array($active,['produkte','kategorien','rabatte'])?'font-bold text-blue-600':'hover:text-blue-600'; ?>">Shop</summary>
+            <div class="pl-4 space-y-1 md:absolute md:left-0 md:top-full md:bg-white md:border md:rounded md:shadow md:p-2 md:w-40 md:pl-0">
+                <a href="produkte.php" class="block <?php echo $active==='produkte'?'font-bold text-blue-600':'hover:text-blue-600'; ?>">Produkte</a>
+                <a href="kategorien.php" class="block <?php echo $active==='kategorien'?'font-bold text-blue-600':'hover:text-blue-600'; ?>">Kategorien</a>
+                <a href="rabattcodes.php" class="block <?php echo $active==='rabatte'?'font-bold text-blue-600':'hover:text-blue-600'; ?>">Rabatte</a>
+            </div>
+        </details>
+        <details class="group md:relative">
+            <summary class="cursor-pointer list-none flex items-center <?php echo in_array($active,['seiten','builder','templates'])?'font-bold text-blue-600':'hover:text-blue-600'; ?>">Inhalte</summary>
+            <div class="pl-4 space-y-1 md:absolute md:left-0 md:top-full md:bg-white md:border md:rounded md:shadow md:p-2 md:w-40 md:pl-0">
+                <a href="pages.php" class="block <?php echo $active==='seiten'?'font-bold text-blue-600':'hover:text-blue-600'; ?>">Seiten</a>
+                <a href="modular_builder.php" class="block <?php echo $active==='builder'?'font-bold text-blue-600':'hover:text-blue-600'; ?>">Builder</a>
+                <a href="templates.php" class="block <?php echo $active==='templates'?'font-bold text-blue-600':'hover:text-blue-600'; ?>">Templates</a>
+            </div>
+        </details>
+        <details class="group md:relative">
+            <summary class="cursor-pointer list-none flex items-center <?php echo in_array($active,['bestellungen','insights'])?'font-bold text-blue-600':'hover:text-blue-600'; ?>">Auswertung</summary>
+            <div class="pl-4 space-y-1 md:absolute md:left-0 md:top-full md:bg-white md:border md:rounded md:shadow md:p-2 md:w-40 md:pl-0">
+                <a href="bestellungen.php" class="block <?php echo $active==='bestellungen'?'font-bold text-blue-600':'hover:text-blue-600'; ?>">Bestellungen</a>
+                <a href="insights.php" class="block <?php echo $active==='insights'?'font-bold text-blue-600':'hover:text-blue-600'; ?>">Insights</a>
+            </div>
+        </details>
+        <a href="popup_builder.php" class="md:ml-auto <?php echo $active==='popups'?'font-bold text-blue-600':'hover:text-blue-600'; ?>">Popups</a>
+        <a href="design.php" class="<?php echo $active==='design'?'font-bold text-blue-600':'hover:text-blue-600'; ?>">Design</a>
+        <a href="customize.php" class="<?php echo $active==='customize'?'font-bold text-blue-600':'hover:text-blue-600'; ?>">Website bearbeiten</a>
+    </nav>
+</header>
+<script>
+    document.addEventListener('DOMContentLoaded',function(){
+        var b=document.getElementById('menuBtn');
+        var n=document.getElementById('navLinks');
+        if(b&&n){
+            b.addEventListener('click',function(){n.classList.toggle('hidden');});
+        }
+    });
+</script>
+<?php
+}
+?>


### PR DESCRIPTION
## Summary
- add `admin_header()` helper to centralize admin navigation
- regroup navigation items with dropdowns
- use helper across admin pages

## Testing
- `php -l inc/admin_header.php`
- `for f in admin/{bestellungen.php,customize.php,dashboard.php,edit_page.php,insights.php,kategorien.php,pages.php,produkte.php,rabattcodes.php,templates.php}; do php -l $f; done`

------
https://chatgpt.com/codex/tasks/task_e_684ca2d78844832182e310b68dbf2f01