### PR TITLE
Introduce live editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Im Header der Seite befindet sich außerdem ein Button, um zwischen Light- und D
 Unter "Seiten" gibt es einen einfachen Drag‑and‑Drop Website‑Editor ohne Fremdbibliotheken. Damit lassen sich Text‑ und Bildelemente inline bearbeiten und frei anordnen. Die resultierenden HTML‑Strukturen werden in der Datenbank gespeichert und auf den jeweiligen Seiten ausgegeben.
 Neu ist außerdem eine Seite "Templates" im Adminbereich. Dort finden sich CSS‑Vorlagen, etwa für Ladeanimationen, die man per Drag & Drop direkt in den Editor ziehen kann.
 
-Ebenfalls neu ist ein modularer visueller Page Builder. Die zugehörigen Dateien befinden sich im Verzeichnis `pagebuilder` und können im Adminbereich über den Menüpunkt "Builder" aufgerufen werden. Jedes Widget besteht aus einer PHP-Datei sowie einem HTML-Template. Per Drag & Drop können aktuell zehn Beispiel-Widgets wie Text, Bild oder Video auf die Seite gezogen werden. Neu ist außerdem ein Breakpoint-System für Desktop, Tablet und Mobile. Für jeden Viewport lassen sich individuelle Einstellungen speichern und die Vorschau im Editor umschalten.
+Der Builder wurde durch einen Live‑Editor ersetzt. Beim Aufruf des Menüpunkts "Builder" erscheint nun direkt die echte Seite in einem Editor‑Fenster. Texte lassen sich inline bearbeiten, Bilder austauschen und komplette Abschnitte per Drag & Drop verschieben. Änderungen werden per AJAX in `builder_pages` gespeichert.
 
 Der Builder kann nun auch für bestehende Shop-Seiten wie die Startseite, Kategorien oder CMS-Seiten verwendet werden. Liegt für eine Seite ein Eintrag in `builder_pages` vor, ersetzt das dort gespeicherte Layout den regulären Inhalt. Über den Parameter `?classic=1` lässt sich jederzeit zum Standardlayout zurückkehren.
 

--- a/admin/layout_library.php
+++ b/admin/layout_library.php
@@ -31,7 +31,7 @@ $templates=$pdo->query('SELECT id,name,html FROM builder_templates ORDER BY name
     <nav class="flex space-x-8 max-w-5xl mx-auto px-4 pb-4">
         <a href="dashboard.php" class="hover:text-blue-600">Dashboard</a>
         <a href="pages.php" class="hover:text-blue-600">Seiten</a>
-        <a href="modular_builder.php" class="hover:text-blue-600">Builder</a>
+        <a href="live_builder.php" class="hover:text-blue-600">Builder</a>
         <a href="popup_builder.php" class="hover:text-blue-600">Popups</a>
         <a href="layout_library.php" class="font-bold text-blue-600">Layouts</a>
     </nav>

--- a/admin/live_builder.php
+++ b/admin/live_builder.php
@@ -1,0 +1,73 @@
+<?php
+session_start();
+if(!isset($_SESSION['admin'])){header('Location: ../login.php');exit;}
+require '../inc/db.php';
+require_once '../inc/admin_header.php';
+
+$slug = $_GET['slug'] ?? '';
+$title = '';
+$id = 0;
+$layout = '';
+if($slug){
+    $stmt = $pdo->prepare('SELECT * FROM builder_pages WHERE slug=?');
+    $stmt->execute([$slug]);
+    if($row = $stmt->fetch(PDO::FETCH_ASSOC)){
+        $title = $row['title'];
+        $id = $row['id'];
+        $data = json_decode($row['layout'], true);
+        $layout = $data['html'] ?? '';
+    }
+}
+
+$pageOptions = [];
+foreach($pdo->query('SELECT slug,title FROM pages ORDER BY title') as $row){
+    $pageOptions[$row['slug']] = $row['title'];
+}
+foreach($pdo->query('SELECT slug,title FROM builder_pages ORDER BY title') as $row){
+    if(!isset($pageOptions[$row['slug']])) $pageOptions[$row['slug']] = $row['title'];
+}
+
+?>
+<!DOCTYPE html>
+<html lang="de">
+<head>
+<meta charset="UTF-8">
+<title>Live Editor – nezbi Admin</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="https://cdn.tailwindcss.com"></script>
+<link href="https://fonts.googleapis.com/css?family=Inter:400,600&display=swap" rel="stylesheet">
+<script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
+<link rel="stylesheet" href="../assets/live-editor.css">
+<style>body{font-family:'Inter',sans-serif;}</style>
+</head>
+<body class="bg-gray-50 text-gray-900">
+<?php admin_header('builder'); ?>
+<main class="max-w-full mx-auto p-4">
+<div class="flex h-screen overflow-hidden">
+    <aside class="w-64 pr-4 space-y-4" id="editorSidebar">
+        <select id="pageSelect" class="w-full border px-2 py-1 rounded">
+            <option value="">Seite wählen...</option>
+            <?php foreach($pageOptions as $pslug=>$ptitle): ?>
+                <option value="<?= htmlspecialchars($pslug) ?>" <?= $pslug===$slug?'selected':'' ?>><?= htmlspecialchars($ptitle) ?></option>
+            <?php endforeach; ?>
+        </select>
+        <input type="text" id="pageTitle" class="w-full border px-2 py-1 rounded" placeholder="Titel" value="<?= htmlspecialchars($title) ?>">
+        <div class="space-y-2">
+            <button type="button" id="addText" class="w-full bg-gray-200 rounded px-2 py-1">Text</button>
+            <button type="button" id="addImage" class="w-full bg-gray-200 rounded px-2 py-1">Bild</button>
+            <button type="button" id="savePage" class="w-full bg-blue-600 text-white rounded px-2 py-1">Speichern</button>
+        </div>
+    </aside>
+    <iframe id="editorFrame" class="flex-1 border" src="" data-slug="<?= htmlspecialchars($slug) ?>" data-id="<?= $id ?>"></iframe>
+</div>
+</main>
+<script src="../assets/live-editor.js"></script>
+<script>
+window.liveEditorConfig = {
+    slug: <?= json_encode($slug) ?>,
+    id: <?= json_encode($id) ?>,
+    layout: <?= json_encode($layout) ?>
+};
+</script>
+</body>
+</html>

--- a/admin/modular_builder.php
+++ b/admin/modular_builder.php
@@ -1,8 +1,8 @@
 <?php
 session_start();
 if(!isset($_SESSION['admin'])){header('Location: ../login.php');exit;}
-require '../inc/db.php';
-require '../pagebuilder/builder.php';
+header('Location: live_builder.php');
+exit;
 
 $id = isset($_GET['id']) ? intval($_GET['id']) : 0;
 $page = ['title' => '', 'slug' => '', 'layout' => ''];

--- a/admin/page_builder.php
+++ b/admin/page_builder.php
@@ -53,7 +53,7 @@ if($_SERVER['REQUEST_METHOD']==='POST' && !$action){
     <nav class="flex space-x-8 max-w-5xl mx-auto px-4 pb-4">
         <a href="dashboard.php" class="hover:text-blue-600">Dashboard</a>
         <a href="pages.php" class="font-bold text-blue-600">Seiten</a>
-        <a href="modular_builder.php" class="hover:text-blue-600">Builder</a>
+        <a href="live_builder.php" class="hover:text-blue-600">Builder</a>
         <a href="popup_builder.php" class="hover:text-blue-600">Popups</a>
     </nav>
 </header>

--- a/admin/popup_builder.php
+++ b/admin/popup_builder.php
@@ -59,7 +59,7 @@ foreach($pdo->query('SELECT slug,title FROM builder_pages ORDER BY title') as $r
     <nav class="flex space-x-8 max-w-5xl mx-auto px-4 pb-4">
         <a href="dashboard.php" class="hover:text-blue-600">Dashboard</a>
         <a href="pages.php" class="hover:text-blue-600">Seiten</a>
-        <a href="modular_builder.php" class="hover:text-blue-600">Builder</a>
+        <a href="live_builder.php" class="hover:text-blue-600">Builder</a>
         <a href="popup_builder.php" class="font-bold text-blue-600">Popups</a>
         <a href="layout_library.php" class="hover:text-blue-600">Layouts</a>
     </nav>

--- a/assets/live-editor.css
+++ b/assets/live-editor.css
@@ -1,0 +1,2 @@
+#editorSidebar button{cursor:pointer}
+#editorFrame{width:100%;}

--- a/assets/live-editor.js
+++ b/assets/live-editor.js
@@ -1,0 +1,108 @@
+(function(){
+  const cfg = window.liveEditorConfig || {};
+  const frame = document.getElementById('editorFrame');
+  const pageSelect = document.getElementById('pageSelect');
+  const saveBtn = document.getElementById('savePage');
+  const addTextBtn = document.getElementById('addText');
+  const addImageBtn = document.getElementById('addImage');
+  const pageTitle = document.getElementById('pageTitle');
+  let currentSlug = cfg.slug || '';
+  let currentId = cfg.id || 0;
+  let currentLayout = cfg.layout || '';
+
+  async function loadPreview(){
+    if(!currentSlug && !currentLayout){ frame.srcdoc = ''; return; }
+    const res = await fetch('../pagebuilder/render_preview.php', {
+      method:'POST',
+      headers:{'Content-Type':'application/json'},
+      body: JSON.stringify({slug: currentSlug, layout: currentLayout})
+    });
+    frame.srcdoc = res.ok ? await res.text() : '';
+  }
+
+  function makeEditable(doc){
+    doc.querySelectorAll('h1,h2,h3,h4,h5,h6,p,div,li,span').forEach(el=>{
+      if(el.children.length===0 && el.tagName!=='IMG'){
+        el.setAttribute('contenteditable','true');
+      }
+    });
+    doc.querySelectorAll('img').forEach(img=>{
+      img.addEventListener('click',()=>{
+        const input=document.createElement('input');
+        input.type='file';
+        input.accept='image/*';
+        input.onchange=()=>{
+          const file=input.files[0];
+          if(file){
+            const reader=new FileReader();
+            reader.onload=e=>{ img.src=e.target.result; markDirty(); };
+            reader.readAsDataURL(file);
+          }
+        };
+        input.click();
+      });
+    });
+    new Sortable(doc.body,{animation:150,draggable:'.pb-item',onEnd:markDirty});
+  }
+
+  function markDirty(){
+    currentLayout = frame.contentDocument.body.innerHTML;
+  }
+
+  async function loadPage(slug){
+    if(!slug){ currentSlug=''; currentId=0; currentLayout=''; loadPreview(); return; }
+    const res = await fetch('../pagebuilder/load_page.php?slug='+encodeURIComponent(slug));
+    if(res.ok){
+      const data = await res.json();
+      currentSlug = data.slug;
+      currentId = data.id;
+      pageTitle.value = data.title;
+      currentLayout = data.layout;
+      await loadPreview();
+    }
+  }
+
+  async function savePage(){
+    if(!currentSlug) return;
+    currentLayout = frame.contentDocument.body.innerHTML;
+    const payload = {id:currentId,title:pageTitle.value,slug:currentSlug,layout:currentLayout};
+    const res = await fetch('../pagebuilder/save_page.php', {
+      method:'POST',
+      headers:{'Content-Type':'application/json'},
+      body: JSON.stringify(payload)
+    });
+    if(res.ok){ alert('Gespeichert'); }
+    else alert('Fehler beim Speichern');
+  }
+
+  frame.addEventListener('load',()=>{
+    const doc = frame.contentDocument;
+    if(doc) makeEditable(doc);
+  });
+
+  pageSelect.addEventListener('change',()=>{
+    const slug = pageSelect.value;
+    loadPage(slug);
+  });
+
+  saveBtn.addEventListener('click',savePage);
+
+  addTextBtn.addEventListener('click',()=>{
+    const doc=frame.contentDocument; if(!doc) return;
+    const div=doc.createElement('div');
+    div.className='pb-item';
+    div.textContent='Neuer Text';
+    doc.body.appendChild(div); makeEditable(doc); markDirty();
+  });
+  addImageBtn.addEventListener('click',()=>{
+    const doc=frame.contentDocument; if(!doc) return;
+    const img=doc.createElement('img');
+    img.src='';
+    const wrap=doc.createElement('div');
+    wrap.className='pb-item';
+    wrap.appendChild(img); doc.body.appendChild(wrap);
+    makeEditable(doc); markDirty();
+  });
+
+  loadPreview();
+})();

--- a/inc/admin_header.php
+++ b/inc/admin_header.php
@@ -29,7 +29,7 @@ function admin_header(string $active = '') {
             <summary class="cursor-pointer list-none flex items-center <?php echo in_array($active,['seiten','builder','templates'])?'font-bold text-blue-600':'hover:text-blue-600'; ?>">Inhalte</summary>
             <div class="pl-4 space-y-1 md:absolute md:left-0 md:top-full md:bg-white md:border md:rounded md:shadow md:p-2 md:w-40 md:pl-0">
                 <a href="pages.php" class="block <?php echo $active==='seiten'?'font-bold text-blue-600':'hover:text-blue-600'; ?>">Seiten</a>
-                <a href="modular_builder.php" class="block <?php echo $active==='builder'?'font-bold text-blue-600':'hover:text-blue-600'; ?>">Builder</a>
+                <a href="live_builder.php" class="block <?php echo $active==='builder'?'font-bold text-blue-600':'hover:text-blue-600'; ?>">Builder</a>
                 <a href="templates.php" class="block <?php echo $active==='templates'?'font-bold text-blue-600':'hover:text-blue-600'; ?>">Templates</a>
             </div>
         </details>


### PR DESCRIPTION
## Summary
- replace builder links with a new `live_builder.php`
- add simple live editor implementation with iframe preview
- redirect old `modular_builder.php` to the new editor
- document the change in the README

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_684ca6bb7014832198cca6c6e427b746