### PR TITLE
Add employee accounts management

### DIFF
--- a/admin/mitarbeiter.php
+++ b/admin/mitarbeiter.php
@@ -1,0 +1,142 @@
+<?php
+session_start();
+if (!isset($_SESSION['admin'])) {
+    header('Location: ../login.php');
+    exit;
+}
+require '../inc/db.php';
+require '../inc/admin_header.php';
+// ensure rechte column exists (for older db)
+try { $pdo->query("SELECT rechte FROM admins LIMIT 1"); }
+catch (PDOException $e) { $pdo->exec("ALTER TABLE admins ADD COLUMN rechte TEXT"); }
+
+// define available rights
+$allRights = [
+    'add_products' => 'Produkte hinzufügen',
+    'edit_prices' => 'Preise ändern',
+    'edit_products' => 'Produkte anpassen',
+    'manage_categories' => 'Kategorien verwalten',
+    'manage_orders' => 'Bestellungen einsehen',
+    'edit_pages' => 'Seiten bearbeiten'
+];
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $action = $_POST['action'] ?? 'add';
+    $rechte = isset($_POST['rechte']) && is_array($_POST['rechte']) ? implode(',', $_POST['rechte']) : '';
+    if ($action === 'add') {
+        $stmt = $pdo->prepare("INSERT INTO admins (username, passwort, rechte) VALUES (?,?,?)");
+        $stmt->execute([
+            $_POST['username'] ?? '',
+            password_hash($_POST['passwort'] ?? '', PASSWORD_DEFAULT),
+            $rechte
+        ]);
+    } elseif ($action === 'update' && isset($_POST['id'])) {
+        $id = intval($_POST['id']);
+        if (!empty($_POST['passwort'])) {
+            $stmt = $pdo->prepare("UPDATE admins SET passwort=?, rechte=? WHERE id=?");
+            $stmt->execute([
+                password_hash($_POST['passwort'], PASSWORD_DEFAULT),
+                $rechte,
+                $id
+            ]);
+        } else {
+            $stmt = $pdo->prepare("UPDATE admins SET rechte=? WHERE id=?");
+            $stmt->execute([$rechte, $id]);
+        }
+        // Wenn eigener Account bearbeitet wurde, Session updaten
+        if ($id === intval($_SESSION['admin'])) {
+            $_SESSION['rechte'] = $rechte ? explode(',', $rechte) : [];
+        }
+    } elseif ($action === 'delete' && isset($_POST['id'])) {
+        $id = intval($_POST['id']);
+        if ($id !== intval($_SESSION['admin'])) {
+            $pdo->prepare("DELETE FROM admins WHERE id=?")->execute([$id]);
+        }
+    }
+}
+
+$admins = $pdo->query("SELECT * FROM admins ORDER BY id")->fetchAll(PDO::FETCH_ASSOC);
+?>
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <title>Mitarbeiter verwalten – nezbi Admin</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+      tailwind.config = {
+        theme: {
+          fontFamily: {
+            sans: ['Inter', 'system-ui', 'sans-serif'],
+          }
+        }
+      }
+    </script>
+    <link href="https://fonts.googleapis.com/css?family=Inter:400,600&display=swap" rel="stylesheet">
+    <style>body { font-family: 'Inter', sans-serif; }</style>
+</head>
+<body class="bg-gray-50 text-gray-900">
+    <?php admin_header('mitarbeiter'); ?>
+    <main class="max-w-5xl mx-auto px-4 py-10">
+        <h1 class="text-2xl font-bold mb-8">Mitarbeiter</h1>
+        <form method="post" class="bg-white shadow rounded-xl p-6 mb-10">
+            <input type="hidden" name="action" value="add">
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <input name="username" class="border px-3 py-2 rounded" placeholder="Benutzername" required>
+                <input name="passwort" type="password" class="border px-3 py-2 rounded" placeholder="Passwort" required>
+            </div>
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
+                <?php foreach ($allRights as $key => $label): ?>
+                    <label class="flex items-center gap-2"><input type="checkbox" name="rechte[]" value="<?= $key ?>"> <?= $label ?></label>
+                <?php endforeach; ?>
+            </div>
+            <button class="mt-4 px-5 py-2 rounded-xl bg-blue-600 text-white">Mitarbeiter anlegen</button>
+        </form>
+        <div class="overflow-x-auto">
+        <table class="w-full bg-white shadow rounded-xl min-w-max">
+            <thead class="bg-gray-100">
+                <tr>
+                    <th class="p-2 text-left">ID</th>
+                    <th class="p-2 text-left">Benutzer</th>
+                    <th class="p-2 text-left">Rechte</th>
+                    <th class="p-2">Aktionen</th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php foreach ($admins as $a): $rights = $a['rechte'] ? explode(',', $a['rechte']) : []; ?>
+                <form id="u<?= $a['id'] ?>" method="post"></form>
+                <tr class="border-t">
+                    <td class="p-2"><?= $a['id'] ?></td>
+                    <td class="p-2"><?= htmlspecialchars($a['username']) ?></td>
+                    <td class="p-2">
+                        <div class="grid grid-cols-1 md:grid-cols-2 gap-2">
+                        <?php foreach ($allRights as $key => $label): ?>
+                            <label class="flex items-center gap-1">
+                                <input form="u<?= $a['id'] ?>" type="checkbox" name="rechte[]" value="<?= $key ?>" <?= in_array($key, $rights) ? 'checked' : '' ?>>
+                                <span><?= $label ?></span>
+                            </label>
+                        <?php endforeach; ?>
+                        </div>
+                        <input form="u<?= $a['id'] ?>" type="password" name="passwort" placeholder="Passwort neu" class="border px-2 py-1 rounded mt-2">
+                        <input form="u<?= $a['id'] ?>" type="hidden" name="action" value="update">
+                        <input form="u<?= $a['id'] ?>" type="hidden" name="id" value="<?= $a['id'] ?>">
+                    </td>
+                    <td class="p-2">
+                        <button form="u<?= $a['id'] ?>" class="px-3 py-1 bg-blue-600 text-white rounded mr-2">Speichern</button>
+                        <?php if ($a['id'] != $_SESSION['admin']): ?>
+                        <form method="post" onsubmit="return confirm('Account wirklich löschen?')" class="inline">
+                            <input type="hidden" name="action" value="delete">
+                            <input type="hidden" name="id" value="<?= $a['id'] ?>">
+                            <button class="px-3 py-1 bg-red-600 text-white rounded">Löschen</button>
+                        </form>
+                        <?php endif; ?>
+                    </td>
+                </tr>
+                <?php endforeach; ?>
+            </tbody>
+        </table>
+        </div>
+    </main>
+</body>
+</html>

--- a/admin/produkte.php
+++ b/admin/produkte.php
@@ -4,6 +4,11 @@ if (!isset($_SESSION['admin'])) {
     header('Location: ../login.php');
     exit;
 }
+$rights = $_SESSION['rechte'] ?? [];
+if (!in_array('add_products', $rights) && !in_array('edit_products', $rights) && !in_array('edit_prices', $rights)) {
+    echo '<p class="p-4">Keine Berechtigung.</p>';
+    exit;
+}
 require '../inc/db.php';
 require '../inc/admin_header.php';
 // Automatische Aktualisierung der Datenbank um neue Spalten

--- a/inc/admin_header.php
+++ b/inc/admin_header.php
@@ -40,6 +40,7 @@ function admin_header(string $active = '') {
                 <a href="insights.php" class="block <?php echo $active==='insights'?'font-bold text-blue-600':'hover:text-blue-600'; ?>">Insights</a>
             </div>
         </details>
+        <a href="mitarbeiter.php" class="<?php echo $active==='mitarbeiter'?'font-bold text-blue-600':'hover:text-blue-600'; ?>">Mitarbeiter</a>
         <a href="popup_builder.php" class="md:ml-auto <?php echo $active==='popups'?'font-bold text-blue-600':'hover:text-blue-600'; ?>">Popups</a>
         <a href="design.php" class="<?php echo $active==='design'?'font-bold text-blue-600':'hover:text-blue-600'; ?>">Design</a>
         <a href="customize.php" class="<?php echo $active==='customize'?'font-bold text-blue-600':'hover:text-blue-600'; ?>">Website bearbeiten</a>

--- a/inc/db.php
+++ b/inc/db.php
@@ -101,3 +101,6 @@ try {
         $pdo->exec("CREATE TABLE IF NOT EXISTS builder_templates (id INT AUTO_INCREMENT PRIMARY KEY, name VARCHAR(200), html TEXT)");
     }
 }
+
+// Spalte fuer Mitarbeiterrechte nachruesten
+ensureColumn($pdo, 'admins', 'rechte', 'TEXT');

--- a/login.php
+++ b/login.php
@@ -10,6 +10,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $admin = $stmt->fetch();
     if ($admin && password_verify($_POST['passwort'], $admin['passwort'])) {
         $_SESSION['admin'] = $admin['id'];
+        $_SESSION['rechte'] = $admin['rechte'] ? explode(',', $admin['rechte']) : [];
         header('Location: admin/dashboard.php'); exit;
     } else {
         $error = "Login fehlgeschlagen.";

--- a/sql/setup.sql
+++ b/sql/setup.sql
@@ -25,7 +25,8 @@ CREATE TABLE produkte (
 CREATE TABLE admins (
     id INT PRIMARY KEY AUTO_INCREMENT,
     username VARCHAR(50) NOT NULL,
-    passwort VARCHAR(255) NOT NULL
+    passwort VARCHAR(255) NOT NULL,
+    rechte TEXT
 );
 
 CREATE TABLE bestellungen (
@@ -44,7 +45,7 @@ CREATE TABLE rabattcodes (
 );
 
 -- Beispieladmin, Passwort ist "nezbi" (bitte nach dem Login ändern!)
-INSERT INTO admins (username, passwort) VALUES ('admin', '$2y$10$2m.bMtqb4s3jLS.7BgUVleppmSDZ6Dqf1hnbdWdPNs1naaQgGo0Sy');
+INSERT INTO admins (username, passwort, rechte) VALUES ('admin', '$2y$10$2m.bMtqb4s3jLS.7BgUVleppmSDZ6Dqf1hnbdWdPNs1naaQgGo0Sy', 'add_products,edit_prices,edit_products,manage_categories,manage_orders,edit_pages');
 
 CREATE TABLE pages (
     id INT PRIMARY KEY AUTO_INCREMENT,

--- a/sql/setup_sqlite.sql
+++ b/sql/setup_sqlite.sql
@@ -23,7 +23,8 @@ CREATE TABLE produkte (
 CREATE TABLE admins (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     username TEXT NOT NULL,
-    passwort TEXT NOT NULL
+    passwort TEXT NOT NULL,
+    rechte TEXT
 );
 
 CREATE TABLE bestellungen (
@@ -42,7 +43,7 @@ CREATE TABLE rabattcodes (
 );
 
 -- Beispieladmin, Passwort ist "nezbi" (bitte nach dem Login ändern!)
-INSERT INTO admins (username, passwort) VALUES ('admin', '$2y$10$2m.bMtqb4s3jLS.7BgUVleppmSDZ6Dqf1hnbdWdPNs1naaQgGo0Sy');
+INSERT INTO admins (username, passwort, rechte) VALUES ('admin', '$2y$10$2m.bMtqb4s3jLS.7BgUVleppmSDZ6Dqf1hnbdWdPNs1naaQgGo0Sy', 'add_products,edit_prices,edit_products,manage_categories,manage_orders,edit_pages');
 
 CREATE TABLE pages (
     id INTEGER PRIMARY KEY AUTOINCREMENT,


### PR DESCRIPTION
## Summary
- add admin page to manage employee accounts with permissions
- save rights in admins table and expose via session on login
- ensure rights column exists in database and SQL setup scripts
- link new page in admin navigation and restrict products page when lacking rights

## Testing
- `php -l admin/mitarbeiter.php`
- `php -l admin/produkte.php`
- `php -l inc/admin_header.php`
- `php -l login.php`
- `php -l inc/db.php`


------
https://chatgpt.com/codex/tasks/task_e_685bb0230a6c83218aaca4daf321dcfa